### PR TITLE
phase2: add CH fs[] schema and VM config wiring

### DIFF
--- a/hypervisor/types.go
+++ b/hypervisor/types.go
@@ -7,6 +7,7 @@ type CHVMConfig struct {
 	CPUs    CHCPUConfig      `json:"cpus"`
 	Memory  CHMemoryConfig   `json:"memory"`
 	Disks   []CHDiskConfig   `json:"disks,omitempty"`
+	Fs      []CHFsConfig     `json:"fs,omitempty"`
 	Serial  CHSerialConfig   `json:"serial"`
 	Console CHConsoleConfig  `json:"console"`
 	TPM     *CHTPMConfig     `json:"tpm,omitempty"`
@@ -45,6 +46,14 @@ type CHMemoryConfig struct {
 type CHDiskConfig struct {
 	Path     string `json:"path"`
 	ReadOnly bool   `json:"readonly,omitempty"`
+}
+
+// CHFsConfig describes a single virtio-fs shared filesystem.
+type CHFsConfig struct {
+	Tag       string `json:"tag"`
+	Socket    string `json:"socket"`
+	NumQueues int    `json:"num_queues,omitempty"`
+	QueueSize int    `json:"queue_size,omitempty"`
 }
 
 // CHSerialConfig controls the serial console output.

--- a/types/config.go
+++ b/types/config.go
@@ -20,6 +20,8 @@ type VMConfig struct {
 	KernelPath    string       `json:"kernel_path,omitempty"`
 	InitramfsPath string       `json:"initramfs_path,omitempty"`
 	Cmdline       string       `json:"cmdline,omitempty"`
+	VirtioFSTag   string       `json:"virtiofs_tag,omitempty"`
+	VirtioFSSock  string       `json:"virtiofs_sock,omitempty"`
 	TPMSocketPath string       `json:"tpm_socket_path,omitempty"`
 
 	// Resources

--- a/vm/engine/manager.go
+++ b/vm/engine/manager.go
@@ -1095,6 +1095,14 @@ func buildCHVMConfig(vmCfg *types.VMConfig) *hypervisor.CHVMConfig {
 		}
 	}
 
+	// Phase 2 virtiofs rootfs path uses CH fs[].
+	if vmCfg.VirtioFSTag != "" && vmCfg.VirtioFSSock != "" {
+		cfg.Fs = append(cfg.Fs, hypervisor.CHFsConfig{
+			Tag:    vmCfg.VirtioFSTag,
+			Socket: vmCfg.VirtioFSSock,
+		})
+	}
+
 	// TPM socket is passed via REST payload, not CLI flags.
 	if vmCfg.TPMSocketPath != "" {
 		cfg.TPM = &hypervisor.CHTPMConfig{

--- a/vm/engine/manager_test.go
+++ b/vm/engine/manager_test.go
@@ -1198,6 +1198,37 @@ func TestBuildCHVMConfig_DirectKernelBoot(t *testing.T) {
 	if chCfg.Payload.Firmware != "" {
 		t.Fatalf("payload.firmware should be empty for direct kernel boot, got %q", chCfg.Payload.Firmware)
 	}
+	if len(chCfg.Fs) != 0 {
+		t.Fatalf("fs should be empty for config without virtiofs, got %+v", chCfg.Fs)
+	}
+}
+
+func TestBuildCHVMConfig_DirectKernelBootWithVirtioFS(t *testing.T) {
+	t.Parallel()
+
+	vmCfg := &types.VMConfig{
+		CPUs:          2,
+		MemoryMB:      1024,
+		OverlayPath:   "/tmp/overlay.qcow2",
+		SerialLog:     "/tmp/serial.log",
+		BootStrategy:  types.BootStrategyDirect,
+		KernelPath:    "/boot/vmlinuz",
+		InitramfsPath: "/boot/initrd.img",
+		Cmdline:       "root=cocoon-rootfs rootfstype=virtiofs rw",
+		VirtioFSTag:   "cocoon-rootfs",
+		VirtioFSSock:  "/var/lib/cocoon/vms/vm-test/virtiofsd.sock",
+	}
+
+	chCfg := buildCHVMConfig(vmCfg)
+	if len(chCfg.Fs) != 1 {
+		t.Fatalf("fs entries = %d, want 1", len(chCfg.Fs))
+	}
+	if chCfg.Fs[0].Tag != "cocoon-rootfs" {
+		t.Fatalf("fs[0].tag = %q, want cocoon-rootfs", chCfg.Fs[0].Tag)
+	}
+	if chCfg.Fs[0].Socket != "/var/lib/cocoon/vms/vm-test/virtiofsd.sock" {
+		t.Fatalf("fs[0].socket = %q, want /var/lib/cocoon/vms/vm-test/virtiofsd.sock", chCfg.Fs[0].Socket)
+	}
 }
 
 func TestBuildCHVMConfig_UEFIFirmwareInPayload(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `fs[]` support to Cloud Hypervisor create payload (`CHVMConfig`)
- add `CHFsConfig` type for virtio-fs entries (`tag/socket/num_queues/queue_size`)
- extend VM config schema with optional Phase-2 fields:
  - `virtiofs_tag`
  - `virtiofs_sock`
- wire `buildCHVMConfig` to emit `fs[]` when both `virtiofs_tag` and `virtiofs_sock` are present
- add unit coverage for direct-kernel boot config with/without virtio-fs wiring

## Why
This is PR-1 from issue #7 Phase-2 breakdown. It introduces the CH payload schema surface needed by upcoming OCI runtime work (overlay + virtiofsd lifecycle), without enabling OCI runtime boot yet.

## Scope boundaries
- no change to current qcow2/cloud runtime path
- no OCI runtime enablement in create/run yet
- no virtiofsd process lifecycle in this PR

## Validation
- `go test ./vm/engine ./hypervisor/...`
- `go test ./...`
- `make lint` (linux + darwin)
