### PR TITLE
docs: sync Issue #7 runtime behavior and closure state

### DIFF
--- a/docs/01-boot-contract.md
+++ b/docs/01-boot-contract.md
@@ -9,7 +9,7 @@
 
 This document defines the **Boot Contract** - the core specification for how Cocoon boots virtual machines using Cloud Hypervisor. The contract establishes:
 
-1. **Boot mode strategy**: UEFI (default for cloud images, Phase 1) + Direct kernel boot (for OCI VM images, Phase 2 — not yet implemented)
+1. **Boot mode strategy**: UEFI (default for cloud images) + Direct kernel boot (for OCI VM images; implemented for local OCI-tag runtime path)
 2. **Guest initialization**: systemd (guest image setup is user responsibility)
 3. **I/O mechanisms**: Serial console, future vsock/virtiofs
 4. **Lifecycle semantics**: Start, stop, delete, crash recovery
@@ -58,33 +58,33 @@ This document defines the **Boot Contract** - the core specification for how Coc
 - Firmware binary: `CLOUDHV.fd` from the [cloud-hypervisor/edk2 releases](https://github.com/cloud-hypervisor/edk2/releases)
 - Installed to: `/var/lib/cocoon/firmware/CLOUDHV.fd`
 
-### 1.2 Alternative Boot Mode: Direct Kernel Boot (OCI VM Images) (Phase 2 — Not Yet Implemented)
+### 1.2 Alternative Boot Mode: Direct Kernel Boot (OCI VM Images)
 
-> **Note**: Direct kernel boot is designed but **not yet implemented**. The specification below describes the planned Phase 2 behavior. Phase 1 only supports UEFI boot.
+> **Implementation status**: Direct kernel boot is implemented for OCI VM refs that resolve to local OCI tags. Registry OCI refs can be classified, but runtime start still requires local materialization.
 
 **Direct kernel boot** will be used automatically when the runtime resolver classifies an image as OCI VM. Instead of loading a UEFI firmware binary, Cocoon will pass the kernel, initramfs, and cmdline directly to Cloud Hypervisor.
 
-**When Direct kernel boot will be used** (Phase 2):
+**When Direct kernel boot is used**:
 - OCI VM images where the kernel and initramfs are extracted from the image
 - Eliminates the need for a firmware binary entirely
 - Provides fast, deterministic boot for purpose-built VM images
 
-**How it will work** (Phase 2):
+**How it works**:
 1. Cocoon extracts the kernel and initramfs from the OCI VM image during conversion
 2. Cloud Hypervisor is configured with `payload.kernel`, `payload.initramfs`, and `payload.cmdline` (no `payload.firmware`)
 3. The kernel boots directly with the provided command line
 
-**Cloud Hypervisor REST payload** (Direct kernel boot — Phase 2):
+**Cloud Hypervisor REST payload** (Direct kernel boot):
 ```json
 {
   "payload": {
-    "kernel": "/var/lib/cocoon/vms/vm-123/vmlinuz",
-    "initramfs": "/var/lib/cocoon/vms/vm-123/initrd.img",
-    "cmdline": "root=PARTUUID=<uuid> rw console=ttyS0,115200n8 console=hvc0"
+    "kernel": "/var/lib/cocoon/cache/oci/runtime/{runtime-key}/kernel/vmlinuz",
+    "initramfs": "/var/lib/cocoon/cache/oci/runtime/{runtime-key}/kernel/initrd.img",
+    "cmdline": "console=hvc0 root=cocoon-rootfs rootfstype=virtiofs rw"
   },
+  "fs": [{"tag": "cocoon-rootfs", "socket": "/run/cocoon/vms/vm-123/virtiofsd.sock"}],
   "cpus": {"boot_vcpus": 2, "max_vcpus": 2},
   "memory": {"size": 2147483648},
-  "disks": [{"path": "/var/lib/cocoon/vms/vm-123/overlay.qcow2"}],
   "serial": {"mode": "File", "file": "/var/log/cocoon/vm-123-serial.log"},
   "console": {"mode": "Pty"}
 }
@@ -92,7 +92,7 @@ This document defines the **Boot Contract** - the core specification for how Coc
 
 **Kernel cmdline format**:
 ```
-root=PARTUUID=<uuid> rw console=ttyS0,115200n8 console=hvc0
+root=<virtiofs_tag> rootfstype=virtiofs rw [console=...]
 ```
 
 **Boot detection**: The same serial log pattern matching is used for both UEFI and Direct kernel boot (systemd target patterns, login prompt fallback patterns).
@@ -108,7 +108,7 @@ root=PARTUUID=<uuid> rw console=ttyS0,115200n8 console=hvc0
 | Arch | Firmware | Status |
 |------|----------|--------|
 | x86_64 | CLOUDHV.fd (UEFI) | Phase 1 |
-| x86_64 | Direct kernel boot (OCI) | Phase 2 |
+| x86_64 | Direct kernel boot (OCI) | Implemented (local OCI-tag runtime path) |
 | aarch64 | CLOUDHV.fd (UEFI) | Phase 2 |
 
 ---
@@ -118,7 +118,7 @@ root=PARTUUID=<uuid> rw console=ttyS0,115200n8 console=hvc0
 Cocoon selects the boot mode automatically based on the image type:
 
 - **Non-OCI images** (cloud images, local qcow2 files, URLs): **UEFI boot** with CLOUDHV.fd firmware via `payload.firmware` **(Phase 1 — Implemented)**
-- **OCI VM images** (resolver-classified): **Direct kernel boot** via `payload.kernel` + `payload.initramfs` + `payload.cmdline` **(Phase 2 — Not Yet Implemented)**
+- **OCI VM images** (resolver-classified): **Direct kernel boot** via `payload.kernel` + `payload.initramfs` + `payload.cmdline` (implemented for local OCI-tag runtime path)
 
 The boot strategy is determined at VM creation time and stored immutably in `config.json`.
 
@@ -132,7 +132,7 @@ const (
     // This is the default boot strategy for non-OCI images.
     BootStrategyUEFI   BootStrategy = "uefi"
     // BootStrategyDirect boots with kernel + initramfs + cmdline via REST payload.
-    // Used automatically for OCI VM images. (Phase 2 — Not Yet Implemented)
+    // Used automatically for OCI VM images.
     BootStrategyDirect BootStrategy = "direct"
 )
 
@@ -145,7 +145,7 @@ const DefaultBootStrategy = BootStrategyUEFI
 | Image Type | Boot Strategy | Payload Fields | Firmware | Status |
 |------------|---------------|----------------|----------|--------|
 | Cloud images (qcow2, URL) | UEFI | `payload.firmware` | CLOUDHV.fd | Phase 1 (Implemented) |
-| OCI VM images (auto-detected) | Direct | `payload.kernel` + `payload.initramfs` + `payload.cmdline` | None | Phase 2 (Planned) |
+| OCI VM images (auto-detected) | Direct | `payload.kernel` + `payload.initramfs` + `payload.cmdline` | None | Implemented (local OCI-tag runtime path) |
 
 **No automatic fallback**: Cocoon boots using the strategy determined by the image type. If the boot fails (e.g., firmware missing, kernel not found), the boot fails with an error.
 
@@ -198,7 +198,7 @@ ls -la /sbin/init  # Should be symlink to systemd
 
 2. Firmware/bootloader loads kernel
    └─ UEFI: CLOUDHV.fd → GRUB → vmlinuz (Phase 1)
-   └─ Direct: kernel + initramfs passed directly (Phase 2)
+   └─ Direct: kernel + initramfs passed directly (OCI runtime path)
 
 3. systemd initializes services
    └─ Mounts filesystems, starts networking, reaches multi-user target
@@ -660,7 +660,7 @@ func ValidateBootability(rootfs string) error {
 
 **Firmware**:
 - UEFI: CLOUDHV.fd from `/var/lib/cocoon/firmware/CLOUDHV.fd` (deprecated fallback: `/usr/share/OVMF/OVMF_CODE.fd`) — Phase 1 (Implemented)
-- Direct kernel boot: No firmware needed (kernel + initramfs passed directly) — Phase 2 (Not Yet Implemented)
+- Direct kernel boot: No firmware needed (kernel + initramfs passed directly) — Implemented for local OCI-tag runtime path
 
 **Bootloader**:
 - ESP location: `/boot/efi/EFI/BOOT/BOOTX64.EFI`
@@ -698,10 +698,10 @@ func ValidateBootability(rootfs string) error {
   - [x] Locate UEFI firmware: primary `/var/lib/cocoon/firmware/CLOUDHV.fd`, deprecated fallback `/usr/share/OVMF/OVMF_CODE.fd`
   - [x] Launch CH with UEFI firmware via REST `payload.firmware` (default boot strategy for non-OCI images)
 
-- [ ] **Direct Kernel Boot** (OCI VM images) — **Phase 2 (Not Yet Implemented)**:
-  - [ ] Extract kernel and initramfs from OCI VM images
-  - [ ] Launch CH with `payload.kernel` + `payload.initramfs` + `payload.cmdline`
-  - [ ] Build kernel cmdline with `root=PARTUUID=<uuid> rw console=ttyS0,115200n8 console=hvc0`
+- [x] **Direct Kernel Boot** (OCI VM images) — implemented for local OCI-tag runtime path:
+  - [x] Extract kernel and initramfs from OCI VM images
+  - [x] Launch CH with `payload.kernel` + `payload.initramfs` + `payload.cmdline`
+  - [x] Build kernel cmdline with `root=<virtiofs_tag> rootfstype=virtiofs rw` (+ console entries)
 
 - [x] **Image Conversion** (`image/pipeline/manager.go`, `image/pipeline/convert_linux.go`):
   - [x] Regenerate GRUB config (if needed for console settings)
@@ -737,11 +737,11 @@ func ValidateBootability(rootfs string) error {
 
 **Boot Contract v2.0** establishes:
 
-1. **Boot strategy**: UEFI (cloud images, Phase 1) + Direct kernel boot (OCI VM images, Phase 2 planned)
+1. **Boot strategy**: UEFI (cloud images, Phase 1) + Direct kernel boot (OCI VM images, implemented for local OCI-tag runtime path)
 2. **Guest initialization**: User responsibility (Cocoon does not perform guest init)
 3. **Image requirements**: kernel + bootloader + systemd
 4. **Graceful lifecycle**: ACPI shutdown with timeout
-5. **Production ready**: Works with standard cloud images (Phase 1); OCI VM image direct boot planned for Phase 2
+5. **Production ready**: Works with standard cloud images (Phase 1) and OCI VM direct boot for local OCI-tag runtime path; registry OCI runtime materialization remains Phase 2 follow-up
 
 **Next Steps**:
 - Read `docs/03-hypervisor-integration.md` for CH API details

--- a/docs/04.1-oci-vm-images.md
+++ b/docs/04.1-oci-vm-images.md
@@ -1,9 +1,9 @@
 # OCI VM Image Format
 
 **Version**: 1.0
-**Status**: Implemented (`image build/push/login/tag/inspect/verify/list/remove`); Cocoonfile delta-layer builds are implemented (local OCI `FROM` reuses base layers, other sources rebuild base layers before delta); direct kernel boot and virtiofs rootfs delivery are Phase 2 planned
-**Phase**: Phase 2 (partial)
-**Last Updated**: 2026-02-18
+**Status**: Implemented (`image build/push/login/tag/inspect/verify/list/remove`); Cocoonfile delta-layer builds are implemented (local OCI `FROM` reuses base layers, other sources rebuild base layers before delta); OCI VM direct runtime (`create/run` auto-detection + direct kernel boot + OverlayFS/virtiofsd) is implemented for local OCI tags. OCI VM pull/materialization directly from remote registry refs remains planned.
+**Phase**: Phase 2 (in progress)
+**Last Updated**: 2026-02-19
 
 **Related Documents**: [04-oci-conversion.md](./04-oci-conversion.md), [01-boot-contract.md](./01-boot-contract.md), [11-bootable-oci-build.md](./11-bootable-oci-build.md), [17-volume-passthrough.md](./17-volume-passthrough.md)
 
@@ -88,8 +88,8 @@ This document **extends** OCI support with a new image format purpose-built for 
 | GC for OCI layouts and blobs | **Done** | `storage/local/gc_oci.go` |
 | Unified `image ls` (TYPE column for cloudimg/oci) | **Done** | `cmd/cocoon/images.go` |
 | OCI runtime overlay workspace (OverlayFS mount/unmount/workspace lifecycle) | **Done** | `vm/engine/overlay_runtime.go`, `vm/engine/overlay_runtime_linux.go` |
-| Direct kernel boot (auto-detected OCI runtime path for create/run) | Phase 2 | — |
-| virtiofs rootfs delivery (OverlayFS + virtiofsd) | Phase 2 | — |
+| Direct kernel boot (auto-detected OCI runtime path for create/run) | **Done** (local OCI tag runtime path) | `vm/engine/manager.go`, `vm/engine/image_resolver.go` |
+| virtiofs rootfs delivery (OverlayFS + virtiofsd) | **Done** (local OCI tag runtime path) | `vm/engine/overlay_runtime.go`, `vm/engine/virtiofsd_runtime.go` |
 | OCI VM image pull from registry | Phase 2 | — |
 | Delta customization layers (separate from rootfs) | **Done** (`RUN`/`COPY` builds emit one delta layer per build; local OCI `FROM` reuses base layers) | `oci/build_linux.go`, `oci/delta_linux.go`, `cmd/cocoon/images.go` |
 
@@ -527,7 +527,7 @@ The OCI manifest digest serves as the cache key:
 
 ## 6. Boot Process (Direct Kernel + virtiofs)
 
-> **Phase 2 — Planned**: This section describes functionality that is not yet implemented. Direct kernel boot with virtiofs rootfs delivery will be added in Phase 2.
+> **Current status**: Implemented for local OCI tags resolved by `create`/`run`. Remote registry refs that resolve as OCI VM still require local materialization before runtime start.
 
 ### 6.1 Cloud-Hypervisor REST API Payload
 
@@ -543,7 +543,7 @@ For OCI VM images, Cocoon uses **direct kernel boot** via Cloud Hypervisor's `pa
   "fs": [
     {
       "tag": "cocoon-rootfs",
-      "socket": "/var/lib/cocoon/vms/{vmID}/virtiofsd.sock",
+      "socket": "/run/cocoon/vms/{vmID}/virtiofsd.sock",
       "num_queues": 1,
       "queue_size": 1024
     }
@@ -582,11 +582,11 @@ Boot detection for OCI VM images uses the **same serial log pattern matching** a
 
 No changes to the boot detection logic are required. The detection mechanism is agnostic to how the kernel was loaded (firmware vs. direct).
 
-### 6.5 Initramfs Requirements for virtiofs Root (Phase 2 Planned)
+### 6.5 Initramfs Requirements for virtiofs Root
 
-> **Note**: This section describes the **Phase 2 planned** virtiofs root boot path. The current v1 implementation uses `root=PARTUUID=<uuid>` (standard block device). The kernel cmdline `root=cocoon-rootfs rootfstype=virtiofs` is a **Cocoon-specific convention** that will be used when direct kernel boot is implemented. Stock distribution initramfs images (dracut, initramfs-tools) do not natively support virtiofs as a root filesystem type. The custom `cocoon-virtiofs` dracut module (described below) provides the early-mount logic required to handle this cmdline parameter. Images built without this module will fail to boot.
+> **Implementation note**: OCI runtime normalizes the kernel cmdline to `root=<virtiofs_tag> rootfstype=virtiofs rw` (plus console entries). This means guest initramfs must support virtiofs-root boot.
 
-**The Problem**: The Phase 2 direct kernel boot path will use `root=cocoon-rootfs rootfstype=virtiofs` in the kernel cmdline, which requires the guest initramfs to understand virtiofs root mounting. (The current v1 implementation uses `root=PARTUUID=<uuid>` with standard block device boot — see [section 2.2](#22-config-blob-schema).) Stock cloud-image initramfs images (built by dracut or initramfs-tools) typically handle only block device roots (`/dev/sdX`, `PARTUUID=`, `UUID=`). They may not include the `virtiofs` kernel module or the early-userspace mount logic needed to mount a virtiofs filesystem as `/sysroot` before pivot_root.
+**The Problem**: Direct kernel boot uses `root=cocoon-rootfs rootfstype=virtiofs` (or equivalent custom tag) in kernel cmdline, which requires the guest initramfs to understand virtiofs root mounting. Stock cloud-image initramfs images (built by dracut or initramfs-tools) typically handle only block device roots (`/dev/sdX`, `PARTUUID=`, `UUID=`). They may not include the `virtiofs` kernel module or the early-userspace mount logic needed to mount a virtiofs filesystem as `/sysroot` before pivot_root.
 
 **Required initramfs capabilities**:
 
@@ -594,7 +594,7 @@ No changes to the boot detection logic are required. The detection mechanism is 
 - Early mount logic must execute `mount -t virtiofs cocoon-rootfs /sysroot` (or equivalent) instead of the standard block device mount. The mount source (`cocoon-rootfs`) matches the `virtiofs_tag` in the OCI config blob and the `fs[].tag` in the Cloud Hypervisor config.
 - The `9p` kernel module SHOULD be included as an optional fallback for environments where virtiofs is unavailable (e.g., older hypervisors or debugging scenarios).
 
-**Approach A (Recommended for Phase 2 v1)**: `cocoon image build` generates a custom initramfs during the build process. After extracting the kernel and stock initramfs from the cloud image, the build step invokes dracut to regenerate the initramfs with virtiofs support:
+**Approach A (Recommended)**: `cocoon image build` generates a custom initramfs during the build process. After extracting the kernel and stock initramfs from the cloud image, the build step invokes dracut to regenerate the initramfs with virtiofs support:
 
 ```bash
 dracut --force --add-drivers "virtiofs 9p 9pnet 9pnet_virtio" \
@@ -648,14 +648,14 @@ This approach avoids modifying the cloud image's initramfs but shifts responsibi
 
 ## 7. CLI Changes
 
-> **Phase 2 — Planned**: Runtime auto-routing for `create`/`run` (qcow2/UEFI vs OCI/direct-boot) is not yet implemented. The `image build`, `image push`, `image login`, `image tag`, `image inspect`, `image verify`, `image list`, and `image remove` commands are implemented.
+> **Current status**: Runtime auto-routing for `create`/`run` is implemented. `create`/`run` now resolve image type and route to qcow2/UEFI vs OCI/direct runtime automatically. OCI direct runtime currently requires a local OCI tag (remote registry refs are detected but not yet materialized automatically for runtime).
 
 ### 7.1 New and Modified Commands
 
 | Command | Description |
 |---------|-------------|
-| `cocoon create <ref>` | Create VM from image ref. Runtime resolver selects qcow2/UEFI vs OCI/direct path automatically (OCI direct path is Phase 2 planned). |
-| `cocoon run <ref>` | Create and start VM from image ref with the same auto-resolution behavior as `create` (OCI direct path is Phase 2 planned). |
+| `cocoon create <ref>` | Create VM from image ref. Runtime resolver selects qcow2/UEFI vs OCI/direct path automatically. |
+| `cocoon run <ref>` | Create and start VM from image ref with the same auto-resolution behavior as `create`. |
 | `cocoon image build <cloudimg> [--tag <ref>] [--file Cocoonfile]` | Build OCI VM image. Cocoonfile `FROM` resolves local paths first, then local OCI tags (implicit `:latest`), then URL/OCI prepare fallback with Docker-like ref normalization. |
 | `cocoon image pull <ref>` | Pull and cache a cloud image (OCI VM pull planned for Phase 2) |
 | `cocoon image push <ref>` | Push a locally built OCI VM image to registry (implicit `:latest` for OCI refs without tag) |
@@ -666,7 +666,7 @@ This approach avoids modifying the cloud image's initramfs but shifts responsibi
 | `cocoon image remove <ref>` | Remove a cached image if unreferenced (for OCI tags, implicit `:latest` lookup; shared layouts are retained until the last referencing tag is removed) |
 | `cocoon image login <registry>` | Log in to a container registry for push operations |
 
-### 7.2 Runtime Resolution Semantics (Phase 2 Planned)
+### 7.2 Runtime Resolution Semantics
 
 `create`/`run` resolve image type first, then select boot path:
 
@@ -679,7 +679,11 @@ This approach avoids modifying the cloud image's initramfs but shifts responsibi
 Routing and boot strategy:
 
 - **Resolved as non-OCI image**: qcow2 path with UEFI (`payload.firmware`)
-- **Resolved as OCI VM image**: direct kernel boot + virtiofs path (Phase 2 planned)
+- **Resolved as OCI VM image**: direct kernel boot + virtiofs path
+
+Current runtime scope:
+- OCI runtime path currently requires a local OCI tag to be present in local store.
+- Registry refs can be classified as OCI VM via manifest media-type probe, but automatic runtime materialization from remote registry refs is not yet implemented.
 
 `--oci` remains hidden as an internal debug override during rollout and is not part of the user-facing contract. There is no user-facing `--boot-strategy` flag.
 
@@ -695,7 +699,7 @@ A key design question for Phase 2 is how Cocoon distinguishes cloud images (qcow
 
 **Decision**: Phase 2 uses **Option A** as the primary mechanism. **Option B** is retained only as hidden/internal debug override during rollout. Option C is rejected due to fragility.
 
-In the current implementation, `--oci` remains hidden and runtime OCI direct boot is not yet enabled; `create`/`run` with refs resolved as OCI VM images return a not-enabled error until Issue #7 runtime milestones land.
+In the current implementation, `--oci` remains hidden as debug override only; runtime OCI direct boot is enabled for local OCI tags.
 
 ### 7.4 Login and Authentication
 
@@ -744,7 +748,9 @@ Login verifies credentials against the registry (checking for `/v2/` endpoint an
         +-- upper/           # NEW: OverlayFS upperdir (per-VM COW writes)
         +-- work/            # NEW: OverlayFS workdir (kernel internal)
         +-- merged/          # NEW: OverlayFS mount point -> virtiofsd serves this
-        +-- virtiofsd.sock   # NEW: virtiofsd socket for this VM
++-- /run/cocoon/vms/
+    +-- {vmID}/
+        +-- virtiofsd.sock   # NEW: rootfs-serving virtiofsd runtime socket
 ```
 
 The OCI build cache uses a **shared blob store** architecture. All blobs (config, kernel layer, rootfs layer, manifest) are stored once in `cache/oci/blobs/sha256/`, keyed by their SHA-256 digest. OCI layouts under `cache/oci/layouts/` contain hardlinks to the shared blobs rather than copies. This enables content-level deduplication across builds -- multiple images sharing the same kernel or rootfs layer store the blob once. See [section 3.7](#37-layer-deduplication-shared-blob-store) for details.
@@ -770,7 +776,7 @@ Key points:
 
 ### 8.1 OCI Cache Lifecycle and Garbage Collection
 
-This section separates current OCI GC behavior (implemented) from the future direct-kernel runtime cache path (Phase 2 planned).
+This section separates OCI build-cache GC behavior from OCI runtime-cache GC behavior.
 
 **Implemented today (OCI build cache path):**
 
@@ -781,7 +787,7 @@ This section separates current OCI GC behavior (implemented) from the future dir
   - remove unreferenced blobs with zero refs in `oci-layer-refs.json`
 - GC uses `gc.lock` plus OCI index locks (`oci-build-tags.lock`, `oci-layer-refs.lock`) and a grace period to avoid races with in-progress builds.
 
-**Phase 2 planned (direct-kernel runtime path, not implemented):**
+**Implemented (direct-kernel runtime path):**
 
 | Object | Location | Lifetime | Shared? |
 |--------|----------|----------|---------|
@@ -789,17 +795,17 @@ This section separates current OCI GC behavior (implemented) from the future dir
 | Per-VM OverlayFS upperdir | `vms/{vm-id}/upper/` | VM lifetime (create to delete) | No, per-VM |
 | Per-VM OverlayFS workdir | `vms/{vm-id}/work/` | VM lifetime (create to delete) | No, per-VM |
 | Per-VM OverlayFS mount | `vms/{vm-id}/merged/` | VM runtime (start to stop) | No, per-VM |
-| Rootfs virtiofsd socket | `/var/lib/cocoon/vms/{vm-id}/virtiofsd.sock` | VM runtime (start to stop) | No, per-VM |
+| Rootfs virtiofsd socket | `/run/cocoon/vms/{vm-id}/virtiofsd.sock` | VM runtime (start to stop) | No, per-VM |
 
-> **Socket location note**: The rootfs-serving socket (`virtiofsd.sock`) is planned under `/var/lib/cocoon/vms/{vm-id}/` alongside the OverlayFS mount. Volume-passthrough sockets (`virtiofs-{tag}.sock`) remain under `/run/cocoon/vms/{vm-id}/` (see [docs/17](./17-volume-passthrough.md)).
+> **Socket location note**: The rootfs-serving socket (`virtiofsd.sock`) lives under `/run/cocoon/vms/{vm-id}/` (runtime path from `RuntimeDir`). Volume-passthrough sockets (`virtiofs-{tag}.sock`) also remain under `/run/cocoon/vms/{vm-id}/` (see [docs/17](./17-volume-passthrough.md)).
 
-For the planned direct-kernel runtime cache, metadata schema and lock files are documented as Phase 2 entries in [docs/05-storage-management.md](./05-storage-management.md) and [docs/06-concurrency.md](./06-concurrency.md). These paths are reserved for the future implementation and are not used by current code.
+Runtime metadata and lock files are documented in [docs/05-storage-management.md](./05-storage-management.md) and [docs/06-concurrency.md](./06-concurrency.md). Current runtime GC/reconcile also uses `db/oci-runtime-refs.json` + `db/oci-runtime-refs.lock` to protect shared runtime cache entries from premature deletion.
 
 ---
 
 ## 9. Boot Strategy Simplification
 
-> **Phase 2 — Planned**: Direct kernel boot remains unimplemented. `cocoon create <oci-ref>` / `cocoon run <oci-ref>` currently return a runtime-not-enabled error after resolver classification. The model below describes the intended Phase 2 behavior.
+> **Current status**: Direct kernel boot is implemented for OCI VM refs that resolve to local OCI tags. Non-OCI refs keep the existing UEFI path.
 
 With OCI VM images, the boot strategy model is simplified to two modes, auto-selected based on image source:
 
@@ -850,13 +856,13 @@ The kernel used to boot the VM comes from the OCI kernel layer, which was extrac
 |---|---|---|---|---|---|
 | Cloud image (qcow2/URL) | UEFI | CLOUDHV.fd | Loaded from disk by bootloader | qcow2 block device | N/A |
 | OCI container image | UEFI | CLOUDHV.fd | Loaded from disk by bootloader | qcow2 (converted from rootfs) | Container registry |
-| OCI VM image (this doc, Phase 2 planned) | Direct kernel + virtiofs | None | Extracted from OCI kernel layer | virtiofs (OverlayFS merged from layers) | Container registry |
+| OCI VM image (this doc) | Direct kernel + virtiofs | None | Extracted from OCI kernel layer | virtiofs (OverlayFS merged from layers) | Container registry |
 
 **Row 1** (Cloud image): The existing default path. Users download a cloud image, Cocoon boots it via UEFI. No registry involved.
 
 **Row 2** (OCI container image): The [docs/04](./04-oci-conversion.md) pipeline. Cocoon pulls a container image, converts it to qcow2, boots via UEFI. Requires a bootloader (GRUB) pre-installed in the container image.
 
-**Row 3** (OCI VM image, Phase 2 planned): This document's target runtime path. Cocoon will build or pull an OCI VM image with separate kernel/rootfs/customization layers, compose them via OverlayFS, and serve the merged filesystem to the guest via virtiofs. Direct kernel boot removes bootloader and block-device dependency for this path.
+**Row 3** (OCI VM image): Direct runtime path in current code for local OCI tags. Cocoon composes rootfs via OverlayFS, serves it through virtiofs, and boots with `payload.kernel`/`payload.initramfs`/`payload.cmdline` (no firmware). Registry OCI refs are detected by resolver, but runtime start still requires local materialization.
 
 ---
 
@@ -867,19 +873,19 @@ The kernel used to boot the VM comes from the OCI kernel layer, which was extrac
 | [docs/04](./04-oci-conversion.md) (OCI Container Conversion) | Implemented | Converts OCI container images to qcow2. Unchanged by this design. |
 | [docs/11](./11-bootable-oci-build.md) (Bootable OCI Build) | Planned | Complementary document covering how to build base bootable images from scratch. The Cocoonfile mechanism in [section 4](#4-user-customization-cocoonfile) of this document supersedes the *build process* in docs/11; the remaining guidance (distro requirements, Dockerfile examples, verification, cloud image workarounds) in docs/11 is maintained independently. |
 | [docs/01](./01-boot-contract.md) (Boot Contract) | Implemented | Already documents direct kernel boot mode alongside UEFI (see Boot Contract v2.0, section 1.2). |
-| [docs/03](./03-hypervisor-integration.md) (Hypervisor Integration) | Implemented | `CHPayloadConfig` in code already has `Initramfs` + `Cmdline` fields. docs/03 has been updated to include all CHPayloadConfig fields (Firmware, Kernel, Initramfs, Cmdline). `CHFsConfig` type definition is implemented in `hypervisor/types.go`; runtime wiring of `fs[]` for OCI boot is Phase 2. |
-| [docs/09](./09-cli-design.md) (CLI Design) | Implemented | `image build`, `image push`, `image login`, `image tag`, `image inspect`, `image verify`, `image list`, and `image remove` commands are implemented. `create`/`run` runtime auto-routing for OCI direct boot remains Phase 2 pending. |
+| [docs/03](./03-hypervisor-integration.md) (Hypervisor Integration) | Implemented | `CHPayloadConfig` and `CHFsConfig` are implemented and used by OCI direct runtime path (`payload.kernel` + `payload.initramfs` + `payload.cmdline` + `fs[]`). |
+| [docs/09](./09-cli-design.md) (CLI Design) | Implemented | `image build`, `image push`, `image login`, `image tag`, `image inspect`, `image verify`, `image list`, and `image remove` commands are implemented. `create`/`run` runtime auto-routing and OCI direct runtime are implemented (local OCI tag scope). |
 | [docs/17](./17-volume-passthrough.md) (Volume Passthrough) | Planned | Defines virtiofsd lifecycle management. The OCI virtiofs boot path reuses the same virtiofsd spawn/teardown machinery. |
 
-### Documents Requiring Updates
+### Remaining Cross-Doc Gaps
 
-Tracking status of cross-document updates required when this design is implemented:
+Tracking status of follow-up updates:
 
 1. **docs/01-boot-contract.md**: ~~Add direct kernel boot as a second boot mode. Document that OCI VM images do not require GRUB or UEFI bootloader on disk.~~ **Done** -- Boot Contract v2.0 already includes section 1.2 (Direct Kernel Boot) and section 1.3 (Boot Mode Selection Logic) covering both UEFI and direct boot modes.
-2. **docs/03-hypervisor-integration.md**: ~~Add `Initramfs` and `Cmdline` fields to `CHPayloadConfig`.~~ **Done in code and docs** -- `hypervisor/types.go` already defines `CHPayloadConfig` with `Firmware`, `Kernel`, `Initramfs`, and `Cmdline` fields. docs/03 has been updated to include all CHPayloadConfig fields (Firmware, Kernel, Initramfs, Cmdline). `CHFsConfig` type definition is implemented in `hypervisor/types.go`; runtime wiring of `fs[]` for OCI boot is Phase 2.
-3. **docs/09-cli-design.md**: **Done** -- `image build`, `image push`, `image login`, `image tag`, `image inspect`, `image verify`, `image list`, and `image remove` commands implemented in `cmd/cocoon/images.go`. **Pending** (Phase 2): Enable resolver-driven OCI runtime auto-routing in `create`/`run`.
+2. **docs/03-hypervisor-integration.md**: ~~Add `Initramfs` and `Cmdline` fields to `CHPayloadConfig`.~~ **Done in code and docs** -- `hypervisor/types.go` defines `CHPayloadConfig` with `Firmware`, `Kernel`, `Initramfs`, and `Cmdline`, and `CHFsConfig` is wired in the OCI runtime path.
+3. **docs/09-cli-design.md**: **Done** -- resolver-driven OCI runtime auto-routing in `create`/`run` is implemented. Remaining gap: registry OCI refs still need local materialization for runtime start.
 4. **docs/11-bootable-oci-build.md**: ~~Mark as superseded by this document.~~ **Updated** -- docs/11 has been expanded from a stub into a substantive design spec covering distro requirements, Dockerfile examples, build pipeline, verification, and Phase 1 vs Phase 2 differences. It is a complementary document to this one, not fully superseded.
-5. **docs/17-volume-passthrough.md**: **Pending** (Phase 2) -- Document virtiofsd lifecycle management (spawn, socket readiness, teardown). The OCI boot path depends on this machinery for serving the OverlayFS-merged root filesystem.
+5. **docs/17-volume-passthrough.md**: **Pending** (Phase 2 follow-up) -- consolidate rootfs-serving and user-volume virtiofsd lifecycle details in one authoritative location.
 
 ---
 
@@ -897,20 +903,20 @@ The `omitempty` tag ensures Phase 1 configs (which lack this field) are treated 
 
 ### 13.2 Field Groups by Image Type
 
-| Field | qcow2 (Phase 1) | oci-vm (Phase 2) |
-|-------|-----------------|------------------|
+| Field | qcow2 (Phase 1) | oci-vm (Phase 2 runtime path) |
+|-------|-----------------|-------------------------------|
 | `image_type` | `"qcow2"` (default when omitted) | `"oci-vm"` |
-| `base_key` | `{checksum_16}_{arch}` | Not used |
-| `firmware_path` | `/var/lib/cocoon/firmware/CLOUDHV.fd` | Not used |
+| `base_key` | `{checksum_16}_{arch}` | Runtime key derived from OCI manifest digest (64-char sha256 hex) |
+| `base_digest_full` | Full source image digest | OCI manifest digest hex (without `sha256:` prefix) |
+| `firmware_path` | `/var/lib/cocoon/firmware/CLOUDHV.fd` | Empty (direct boot does not use firmware) |
 | `boot_strategy` | `"uefi"` | `"direct"` |
-| `overlay_path` | `overlay.qcow2` | Not used |
-| `manifest_digest` | Not used | `sha256:abc123...` |
-| `oci_cache_key` | Not used | Digest pointing to `cache/oci/{digest}/` |
-| `kernel_path` | Not used | Path to extracted vmlinuz |
-| `initramfs_path` | Not used | Path to extracted initrd.img |
-| `cmdline` | Not used | Kernel command line |
-| `virtiofs_tag` | Not used | `"cocoon-rootfs"` (virtiofs filesystem tag for guest `root=` parameter) |
-| `virtiofs_sock` | Not used | Path to rootfs-serving virtiofsd socket |
+| `overlay_path` | `overlay.qcow2` | Empty (rootfs from OverlayFS + virtiofs) |
+| `base_image_path` | Path to cached base qcow2 | Path to OCI runtime rootfs lowerdir |
+| `kernel_path` | Empty | Path to extracted vmlinuz |
+| `initramfs_path` | Empty | Path to extracted initrd.img |
+| `cmdline` | Empty | Kernel command line (virtiofs root) |
+| `virtiofs_tag` | Empty | `"cocoon-rootfs"` (or image-provided tag) |
+| `virtiofs_sock` | Empty | Path to rootfs-serving virtiofsd socket |
 
 ### 13.3 Mutual Exclusivity
 
@@ -925,7 +931,7 @@ This is enforced at VM creation time. `cocoon inspect` displays only the relevan
 
 ### 13.5 Backward Compatibility
 
-VMs with missing `image_type` field default to `"qcow2"` and work unchanged. No config rewrite occurs. New VM configs already persist `image_type` today (`"qcow2"` for current runtime path), and `"oci-vm"` will be persisted once the OCI direct runtime path is enabled.
+VMs with missing `image_type` field default to `"qcow2"` and work unchanged. No config rewrite occurs. New VM configs persist `image_type` for both runtime paths (`"qcow2"` and `"oci-vm"`).
 
 ### 13.6 Warm-Start Interaction
 

--- a/docs/09-cli-design.md
+++ b/docs/09-cli-design.md
@@ -2,8 +2,8 @@
 
 **Version**: 1.0
 **Status**: Implemented
-**Phase**: Phase 1
-**Last Updated**: 2026-02-18
+**Phase**: Phase 1 + Phase 2 (partial)
+**Last Updated**: 2026-02-19
 
 ## ⚠️ Supported Image Contract
 
@@ -17,14 +17,16 @@
 
 2. **Bootable OCI Images** (Custom-built):
    - **Phase 1**: OCI→qcow2 conversion with **strict bootability validation**
-   - Must contain: kernel, initrd, init system (systemd), bootloader
+   - **Phase 2 (implemented scope)**: resolver-driven OCI VM direct runtime (`payload.kernel` + `fs[]`) for local OCI tags
+   - Must contain: kernel, initrd, init system (systemd)
+   - Bootloader requirement applies to the OCI→qcow2 conversion path; direct OCI runtime path does not require bootloader-on-disk
    - **Non-bootable OCI images will fail with clear error**
    - Requires build tooling (see docs/11-bootable-oci-build.md)
 
-**NOT Supported** (Phase 1):
+**NOT Supported** (current):
 - Regular container images (`ubuntu:latest`, `python:3.11`, etc.)
-- These lack kernel/bootloader and will **fail bootability validation**
-- Phase 2 will add auto-conversion capabilities
+- These typically lack kernel/initrd/systemd and will fail bootability validation
+- Automatic "generic container image -> runnable VM" conversion is not provided
 
 See [00-overview.md § Supported Image Contract](./00-overview.md#️-supported-image-contract) for details.
 
@@ -34,7 +36,7 @@ See [00-overview.md § Supported Image Contract](./00-overview.md#️-supported-
 
 This document defines the command-line interface for Cocoon, a lightweight VM management tool built on Cloud Hypervisor. The CLI follows Docker-like patterns for familiarity while exposing VM-specific capabilities like UEFI/Direct kernel boot modes, resource allocation, and lifecycle management.
 
-The design integrates the [Boot Contract](./01-boot-contract.md) decisions, including UEFI boot for cloud images (Phase 1), serial console I/O, and graceful shutdown semantics. Direct kernel boot for OCI VM images is planned for Phase 2 (see [04.1-oci-vm-images.md](./04.1-oci-vm-images.md)). It also leverages the [storage management](./05-storage-management.md) system for efficient copy-on-write disk handling.
+The design integrates the [Boot Contract](./01-boot-contract.md) decisions, including UEFI boot for cloud images, resolver-driven OCI direct runtime for local OCI tags, serial console I/O, and graceful shutdown semantics. It also leverages the [storage management](./05-storage-management.md) system for efficient copy-on-write disk handling.
 
 ## Table of Contents
 
@@ -682,7 +684,7 @@ func runCommand() *cli.Command {
 2. **Print VM ID**: Output the VM ID immediately after Create, **before** boot detection. This allows scripts to capture the ID for cleanup even if Start fails (see `cmd/cocoon/run.go` rationale comment).
 3. **Start VM** (`vmMgr.Start`): Launch CH process, configure via REST, boot VM, poll serial log for boot completion (timeout: config default), transition to RUNNING.
 4. **Background behavior**: VM runs as a background CH process. Serial log is written to disk; use `cocoon logs --follow` to stream.
-   > **Phase 1 note**: All runs are background (CH process). The `--detach/-d` flag is accepted but is a no-op. In Phase 2, non-detach runs will attach to the serial log automatically; `--detach/-d` will then control attach vs. detach mode.
+   > **Current note**: Runs are background-only today. The `--detach/-d` flag is accepted but is currently a no-op.
 5. **Auto-remove** (if `--rm`): The `AutoRemove` flag is recorded in metadata after Start succeeds. When the VM is stopped via `cocoon stop`, the delete flow is triggered automatically. Note: if the VM crashes or is killed externally, auto-remove does not fire. Use `cocoon doctor --fix` for state reconciliation; automatic deletion of crashed `auto_remove` VMs is a future enhancement.
 
 **Example Usage**:
@@ -694,8 +696,8 @@ cocoon run ubuntu-22.04-cloudimg --name myvm --cpus 4 --memory 4G
 # Run VM with auto-remove on stop
 cocoon run --rm ubuntu-22.04-cloudimg --name temp-vm
 
-# Run an OCI VM image (Phase 2 runtime path -- not yet implemented)
-# cocoon run myorg/ubuntu-vm:22.04
+# Run an OCI VM image from local OCI tag store (direct kernel + virtiofs path)
+cocoon run myorg/ubuntu-vm:22.04 --name my-oci-vm
 
 # Run with TPM 2.0 emulation enabled
 cocoon run --tpm ubuntu-22.04-cloudimg --name secure-vm
@@ -712,14 +714,12 @@ cocoon run --boot-timeout 120 ubuntu-22.04-cloudimg --name slow-vm
 
 **IMAGE Parameter**:
 - **Positional argument** (required): Image path, URL, or OCI reference
-- **Phase 1 Support** (Current):
-  - Cloud image qcow2: `/path/to/ubuntu-22.04-cloudimg.qcow2`
-  - Cloud image URL: `https://cloud-images.ubuntu.com/.../ubuntu-22.04.img`
-  - **OCI→qcow2 conversion**: Supported with strict bootability validation
-    - Bootable OCI images: Converted and used successfully
-    - Non-bootable OCI images: **Fail with clear error** (missing kernel/bootloader)
-- **Phase 2 Support** (Planned):
-  - Enhanced bootability diagnostics with specific remediation guidance
+- **Current Support**:
+  - Cloud image qcow2: `/path/to/ubuntu-22.04-cloudimg.qcow2` (UEFI path)
+  - Cloud image URL: `https://cloud-images.ubuntu.com/.../ubuntu-22.04.img` (UEFI path)
+  - Bootable OCI image/container refs: OCI→qcow2 conversion path (UEFI) with strict bootability validation
+  - Local OCI VM tags: direct kernel + virtiofs runtime path (`image_type=oci-vm`)
+  - Registry OCI refs: type detection is supported; runtime start still requires local OCI materialization
 
 ```go
 func createCommand() *cli.Command {
@@ -754,7 +754,7 @@ func createAction(c *cli.Context) error {
 }
 ```
 
-The `createCommand` uses the same `vmCreateFlags()` as `runCommand`, which includes `--name`, `--cpus`, `--memory` (default "2048M"), `--disk`, `--skip-verify`, and `--tpm`. Runtime image-type selection is resolver-driven (user does not need a mode flag). The hidden `--oci` flag remains an internal debug override while Phase 2 runtime wiring is unfinished. Note: `--boot-timeout` is only available on `run` and `start` commands (not `create`, since `create` does not boot the VM).
+The `createCommand` uses the same `vmCreateFlags()` as `runCommand`, which includes `--name`, `--cpus`, `--memory` (default "2048M"), `--disk`, `--skip-verify`, and `--tpm`. Runtime image-type selection is resolver-driven (user does not need a mode flag). The hidden `--oci` flag remains an internal debug override. Note: `--boot-timeout` is only available on `run` and `start` commands (not `create`, since `create` does not boot the VM).
 
 **Example Usage**:
 
@@ -769,9 +769,8 @@ cocoon create ubuntu-22.04-cloudimg --cpus 2 --memory 2G
 cocoon create https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img \
   --name myvm --cpus 4 --memory 8G
 
-# Create from OCI image (Phase 1: requires bootable OCI, else error)
+# Create from local OCI VM tag (direct kernel + virtiofs path)
 cocoon create myorg/ubuntu-bootable:22.04 --name myvm
-# Error if not bootable: "Image is not bootable - missing kernel/bootloader"
 
 # Error: name already taken
 $ cocoon create ubuntu-22.04-cloudimg --name myvm
@@ -2164,7 +2163,7 @@ This CLI design implements the Boot Contract specification:
 
 | Boot Contract Section      | CLI Implementation                                                                                                                        |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| §1 Boot Path Decision      | UEFI boot (Phase 1); resolver-driven OCI direct-boot auto-routing in Phase 2 (not yet implemented)                                        |
+| §1 Boot Path Decision      | UEFI boot for non-OCI refs + resolver-driven OCI direct runtime for local OCI tags; hidden `--oci` remains debug-only                     |
 | §2 Guest Init Model        | Guest initialization is the user's responsibility; DHCP-based network config planned for Phase 2 ([16-networking.md](./16-networking.md)) |
 | §3 I/O Mechanisms          | Serial console via `--serial file=...` (CH flag), `cocoon logs` command                                                                   |
 | §4 Lifecycle Semantics     | `run`, `stop`, `delete`, `kill` commands                                                                                                  |

--- a/docs/10-implementation-roadmap.md
+++ b/docs/10-implementation-roadmap.md
@@ -4,8 +4,9 @@
 **Status**: Historical
 
 > **Note**: Package paths (`pkg/...`) and code skeletons below reflect the original planning structure, not the current implementation. See actual module layout: `config/`, `image/`, `storage/`, `vm/`, `hypervisor/`, `cmd/cocoon/`, `lock/`, `types/`, `utils/`.
+> **Historical sync note (2026-02-19)**: OCI direct runtime from `create/run` is now implemented for local OCI tags (Issue #7 delivery). Remote OCI runtime materialization from registry refs remains follow-up work.
 **Phase**: Phase 1
-**Last Updated**: 2026-02-17
+**Last Updated**: 2026-02-19
 
 ## Executive Summary
 
@@ -61,7 +62,7 @@ This document provides a concrete implementation roadmap for Cocoon Phase 1, syn
 These must be implemented correctly from the start:
 
 1. **Boot Contract Compliance** (docs/01-boot-contract.md)
-   - UEFI boot for cloud images (Phase 1); direct kernel boot for OCI VM images (Phase 2 planned)
+   - UEFI boot for cloud images (Phase 1); direct kernel boot for OCI VM images (implemented for local OCI-tag runtime path)
    - systemd for VM initialization
    - ACPI shutdown with timeout
 

--- a/docs/11-bootable-oci-build.md
+++ b/docs/11-bootable-oci-build.md
@@ -1,9 +1,9 @@
 # Building Bootable OCI Images
 
 **Version**: 1.1
-**Status**: Planned
+**Status**: Phase 2 partial (OCI direct runtime implemented for local OCI tags; build helper and remote OCI runtime materialization remain planned)
 **Phase**: Phase 2
-**Last Updated**: 2026-02-16
+**Last Updated**: 2026-02-19
 
 **Related Documents**: [01-boot-contract.md](./01-boot-contract.md), [04-oci-conversion.md](./04-oci-conversion.md), [04.1-oci-vm-images.md](./04.1-oci-vm-images.md), [09-cli-design.md](./09-cli-design.md)
 
@@ -29,7 +29,7 @@ A **bootable OCI image** in Cocoon's context is an OCI-compliant container image
 - **systemd** as PID 1 (the Boot Contract requires systemd; sysvinit and OpenRC are not supported)
 - A **bootloader** (GRUB2 with EFI support) for the UEFI boot path
 
-The image is published to any OCI-compliant registry (Docker Hub, GHCR, private registries) and consumed by Cocoon via `cocoon image pull`.
+The image is published to any OCI-compliant registry (Docker Hub, GHCR, private registries). Cocoon currently consumes it either via `cocoon image pull` (qcow2 conversion path) or via local OCI tags for the direct OCI runtime path.
 
 ### 1.1 Two Consumption Paths
 
@@ -38,11 +38,11 @@ A bootable OCI image can be consumed in two ways, depending on the Cocoon phase:
 | Path | Phase | Boot Mode | Rootfs Delivery | Requires Bootloader |
 |------|-------|-----------|-----------------|---------------------|
 | OCI-to-qcow2 conversion | Phase 1 | UEFI (`payload.firmware`) | qcow2 block device | Yes (GRUB2 + ESP) |
-| OCI VM image (OverlayFS + virtiofs) | Phase 2 | Direct kernel boot (`payload.kernel`) | virtiofs from OverlayFS-merged layers | No |
+| OCI VM image (OverlayFS + virtiofs) | Phase 2 (implemented scope) | Direct kernel boot (`payload.kernel`) | virtiofs from OverlayFS-merged layers | No |
 
 **Phase 1**: The OCI image is pulled, its rootfs extracted, and converted to a qcow2 disk image with a GPT partition table and ESP. Cloud Hypervisor boots via UEFI firmware (CLOUDHV.fd), which loads GRUB, which loads the kernel from disk. This path requires the image to contain a bootloader.
 
-**Phase 2**: The OCI image is decomposed into discrete layers (kernel, rootfs, customization) as defined in [docs/04.1-oci-vm-images.md](./04.1-oci-vm-images.md). The kernel and initramfs are extracted and passed directly to Cloud Hypervisor via `payload.kernel` and `payload.initramfs`. The rootfs layers are composed via OverlayFS and served to the guest via virtiofs. No bootloader is required on disk. Phase 2 also provides `cocoon image build-bootable`, a helper command that automates the image build process.
+**Phase 2**: The OCI image is decomposed into discrete layers (kernel, rootfs, customization) as defined in [docs/04.1-oci-vm-images.md](./04.1-oci-vm-images.md). The kernel and initramfs are extracted and passed directly to Cloud Hypervisor via `payload.kernel` and `payload.initramfs`. The rootfs layers are composed via OverlayFS and served to the guest via virtiofs. No bootloader is required on disk. Current runtime implementation supports this path for local OCI tags; `cocoon image build-bootable` and remote OCI runtime materialization are follow-up work.
 
 ### 1.2 Relationship to docs/04.1
 
@@ -242,7 +242,7 @@ Dockerfile
 2. docker push myregistry.io/myvm:v1
     |
     v
-3. cocoon image pull myregistry.io/myvm:v1  (Phase 1 and Phase 2: local-first pull/prepare path)
+3. cocoon image pull myregistry.io/myvm:v1  (qcow2 conversion path; OCI direct runtime currently requires local OCI tag materialization)
     |
     v
 4. cocoon image verify myregistry.io/myvm:v1
@@ -283,7 +283,7 @@ cocoon image pull myregistry.io/ubuntu-vm:22.04
 cocoon image pull myregistry.io/ubuntu-vm:22.04
 ```
 
-For Phase 1, this downloads OCI content into the local cache and follows the current qcow2 runtime path. For Phase 2, resolver/classification identifies OCI VM image references ([docs/04.1](./04.1-oci-vm-images.md)) and routes create/run to the direct-boot path without a user-facing mode flag.
+For Phase 1, this downloads OCI content into the local cache and follows the qcow2 runtime path. For Phase 2, resolver/classification identifies OCI VM image references ([docs/04.1](./04.1-oci-vm-images.md)) and routes create/run to the direct-boot path without a user-facing mode flag once the ref is available as a local OCI tag.
 
 **Step 4: `cocoon image verify`**
 
@@ -411,7 +411,7 @@ OCI Image (rootfs) -> Buildah extraction -> guestfish partitioning -> qcow2
 **Rootfs delivery**: qcow2 block device attached to VM
 **Boot chain**: UEFI firmware -> GRUB -> kernel -> systemd
 
-### 6.2 Phase 2: Direct Kernel Boot + OverlayFS + virtiofs
+### 6.2 Phase 2: Direct Kernel Boot + OverlayFS + virtiofs (Implemented Scope)
 
 In Phase 2, bootable OCI images can also be consumed via the [OCI VM Image Format](./04.1-oci-vm-images.md):
 
@@ -439,7 +439,7 @@ OCI Image -> cocoon image build -> OCI VM Image (kernel layer + rootfs layer)
 | Boot speed | Standard (firmware + GRUB chain) | Faster (no firmware init) |
 | Registry deduplication | Per-image (no layer sharing) | Per-layer (kernel/rootfs shared) |
 | Kernel upgrades | Guest can upgrade in-place | Rebuild OCI image (kernel pinned) |
-| Build helper | Manual Dockerfile | `cocoon image build-bootable` |
+| Build helper | Manual Dockerfile | `cocoon image build-bootable` (planned) |
 | Image customization | Rebuild entire image | Cocoonfile (adds overlay layer) |
 | Runtime selection | `cocoon create <image>` (UEFI/qcow2 path) | `cocoon create <ref>` (resolver auto-detects OCI VM refs for direct path) |
 


### PR DESCRIPTION
## Summary
- sync docs with current Issue #7 runtime state
- document that OCI direct runtime (`create/run` auto-detection + direct kernel boot + OverlayFS/virtiofsd) is implemented for local OCI tags
- keep remote OCI runtime materialization as explicit follow-up scope

## Updated Docs
- docs/01-boot-contract.md
- docs/04.1-oci-vm-images.md
- docs/09-cli-design.md
- docs/10-implementation-roadmap.md
- docs/11-bootable-oci-build.md

## Validation
- make lint
- make test
