### PR TITLE
fix: close issue #23 review gaps (code + docs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,7 @@ gh api repos/CMGS/cocoon/pulls/<PR_NUMBER>/reviews --input /tmp/pr-inline.json
 - **Inline comments**: use for concrete code findings -- bugs, style issues,
   security concerns, suggestions. Prefix with severity:
   - `bug:` for correctness issues
+  - `security:` for vulnerabilities, unsafe defaults, or exploit paths
   - `nit:` for style / cosmetic
   - `suggestion:` for non-blocking improvements
   - `question:` for clarification requests

--- a/cmd/cocoon/doctor.go
+++ b/cmd/cocoon/doctor.go
@@ -10,6 +10,7 @@ import (
 	cli "github.com/urfave/cli/v2"
 
 	"github.com/CMGS/cocoon/config"
+	"github.com/CMGS/cocoon/oci"
 	"github.com/CMGS/cocoon/utils"
 )
 
@@ -215,7 +216,25 @@ func runDependencyChecks(app *appContext) []checkResult {
 		}
 	}
 
+	results = append(results, checkOCIBlobRefCleanupHealth())
+
 	return results
+}
+
+func checkOCIBlobRefCleanupHealth() checkResult {
+	failures := oci.BlobRefCleanupFailureCount()
+	if failures == 0 {
+		return checkResult{
+			Name:   "oci/blob-ref-cleanup",
+			Status: "pass",
+			Detail: "no OCI blob-ref cleanup failures observed",
+		}
+	}
+	return checkResult{
+		Name:   "oci/blob-ref-cleanup",
+		Status: "warn",
+		Detail: fmt.Sprintf("%d OCI blob-ref cleanup failure(s) observed; run 'cocoon gc' and inspect logs for warnings", failures),
+	}
 }
 
 // checkSwtpm checks that the swtpm binary is available and reports its version.

--- a/docs/04.1-oci-vm-images.md
+++ b/docs/04.1-oci-vm-images.md
@@ -536,8 +536,8 @@ For OCI VM images, Cocoon uses **direct kernel boot** via Cloud Hypervisor's `pa
 ```json
 {
   "payload": {
-    "kernel": "/var/lib/cocoon/cache/oci/{digest}/vmlinuz",
-    "initramfs": "/var/lib/cocoon/cache/oci/{digest}/initrd.img",
+    "kernel": "/var/lib/cocoon/cache/oci/runtime/{runtimeKey}/kernel/vmlinuz",
+    "initramfs": "/var/lib/cocoon/cache/oci/runtime/{runtimeKey}/kernel/initrd.img",
     "cmdline": "root=cocoon-rootfs rootfstype=virtiofs rw console=ttyS0,115200n8 console=hvc0"
   },
   "fs": [
@@ -551,7 +551,7 @@ For OCI VM images, Cocoon uses **direct kernel boot** via Cloud Hypervisor's `pa
 }
 ```
 
-The `cmdline` value is read from the OCI config blob's `kernel_cmdline` field. The `kernel` and `initramfs` paths point to the extracted files in the OCI cache directory. The `fs[]` entry configures virtiofs to serve the OverlayFS-merged root filesystem to the guest.
+The `cmdline` value is read from the OCI config blob's `kernel_cmdline` field. The `runtimeKey` is derived from the manifest digest (sha256 hex without prefix). The `kernel` and `initramfs` paths point to the extracted files in `cache/oci/runtime/{runtimeKey}/kernel/`. The `fs[]` entry configures virtiofs to serve the OverlayFS-merged root filesystem to the guest.
 
 ### 6.2 virtiofsd Lifecycle
 
@@ -625,7 +625,7 @@ This approach avoids modifying the cloud image's initramfs but shifts responsibi
 **Threat model**:
 
 - **Guest escape via virtiofsd**: A compromised guest could exploit vulnerabilities in virtiofsd (e.g., path traversal, FUSE protocol bugs) to access host files outside the shared directory. Mitigation: `--sandbox=chroot` confines virtiofsd's filesystem view to the OverlayFS merge directory. Even if the guest achieves arbitrary FUSE request crafting, the virtiofsd process itself is chrooted and cannot access host paths outside the merge tree.
-- **Blast radius**: Because the shared directory IS the entire guest rootfs (the OverlayFS merge of lowerdirs + upperdir), a successful escape from the chroot would expose the OverlayFS tree on the host -- specifically the read-only cache directories (`cache/oci/{digest}/rootfs/`, `cache/oci/{digest}/custom-N/`) and the per-VM upper directory (`vms/{vmID}/upper/`). It would NOT expose the entire host filesystem, assuming the chroot sandbox is intact.
+- **Blast radius**: Because the shared directory IS the entire guest rootfs (the OverlayFS merge of lowerdir + upperdir), a successful escape from the chroot would expose the OverlayFS tree on the host -- specifically the read-only runtime cache directory (`cache/oci/runtime/{runtimeKey}/rootfs/`) and the per-VM upper directory (`vms/{vmID}/upper/`). It would NOT expose the entire host filesystem, assuming the chroot sandbox is intact.
 - **Write scope**: Guest writes land in the OverlayFS upperdir (`vms/{vmID}/upper/`). The lowerdir cache is read-only at the OverlayFS level. A guest cannot corrupt the shared base image layers.
 
 **Hardening requirements**:
@@ -727,7 +727,7 @@ Login verifies credentials against the registry (checking for `/v2/` endpoint an
 /var/lib/cocoon/
 +-- cache/
 |   +-- images/              # Existing: qcow2 base images (non-OCI path)
-|   +-- oci/                 # OCI VM image cache (shared blob store + OCI layouts)
+|   +-- oci/                 # OCI VM image cache (shared blob store + OCI layouts + runtime cache)
 |   |   +-- blobs/sha256/    # Shared content-addressed blob store
 |   |   |   +-- {hex}        # Blob files (config, kernel layer, rootfs layer, manifest)
 |   |   +-- layouts/         # OCI layouts (blobs are hardlinks to shared store)
@@ -735,6 +735,12 @@ Login verifies credentials against the registry (checking for `/v2/` endpoint an
 |   |           +-- oci-layout
 |   |           +-- index.json
 |   |           +-- blobs/sha256/{hex}  # Hardlinks to ../../blobs/sha256/{hex}
+|   |   +-- runtime/
+|   |       +-- {runtimeKey}/  # Materialized runtime cache entry (manifest scoped)
+|   |           +-- rootfs/    # Flattened rootfs lowerdir
+|   |           +-- kernel/
+|   |               +-- vmlinuz
+|   |               +-- initrd.img
 |   +-- manifests/           # Existing: OCI manifest cache
 +-- db/
 |   +-- oci-build-tags.json  # Tag index: tag -> layout path mapping
@@ -742,6 +748,8 @@ Login verifies credentials against the registry (checking for `/v2/` endpoint an
 |   +-- oci-build-txn.lock   # Transaction lock: serializes cross-index tag+blob-ref operations
 |   +-- oci-layer-refs.json  # Blob reference tracking: blob digest -> [manifest digests]
 |   +-- oci-layer-refs.lock
+|   +-- oci-runtime-refs.json  # Runtime cache pin tracking: runtimeKey -> [vm-id]
+|   +-- oci-runtime-refs.lock
 +-- firmware/                # Existing: CLOUDHV.fd (UEFI only, not used by OCI path)
 +-- vms/
     +-- {vmID}/
@@ -755,11 +763,11 @@ Login verifies credentials against the registry (checking for `/v2/` endpoint an
 
 The OCI build cache uses a **shared blob store** architecture. All blobs (config, kernel layer, rootfs layer, manifest) are stored once in `cache/oci/blobs/sha256/`, keyed by their SHA-256 digest. OCI layouts under `cache/oci/layouts/` contain hardlinks to the shared blobs rather than copies. This enables content-level deduplication across builds -- multiple images sharing the same kernel or rootfs layer store the blob once. See [section 3.7](#37-layer-deduplication-shared-blob-store) for details.
 
-The OverlayFS mount command for a VM with two customization layers:
+The OverlayFS mount command for a VM using the materialized OCI runtime cache:
 
 ```bash
 mount -t overlay overlay \
-  -o lowerdir=/var/lib/cocoon/cache/oci/{digest}/custom-2:/var/lib/cocoon/cache/oci/{digest}/custom-1:/var/lib/cocoon/cache/oci/{digest}/rootfs,\
+  -o lowerdir=/var/lib/cocoon/cache/oci/runtime/{runtimeKey}/rootfs,\
 upperdir=/var/lib/cocoon/vms/{vmID}/upper,\
 workdir=/var/lib/cocoon/vms/{vmID}/work \
   /var/lib/cocoon/vms/{vmID}/merged
@@ -770,9 +778,23 @@ Key points:
 - The `cache/oci/blobs/sha256/` directory is the shared content-addressed blob store. All blob data (config, kernel layer, rootfs layer, manifest) lives here exactly once, regardless of how many tags reference it.
 - The `cache/oci/layouts/{sha256-hex}/` directories contain OCI layouts keyed by full `sha256(tag + "@" + manifest_digest)`. The blobs inside each layout's `blobs/sha256/` subdirectory are **hardlinks** to the shared blob store, not copies. This means a layout removal only decrements the hardlink count; the blob data persists as long as at least one reference exists.
 - `db/oci-layer-refs.json` maps blob digests to the manifest digests that reference them. This reference count is used by GC to determine which shared blobs are safe to remove.
+- `db/oci-runtime-refs.json` maps `runtimeKey` to VM IDs that currently pin runtime cache entries under `cache/oci/runtime/`.
 - Per-VM state under `vms/{vmID}/` includes OverlayFS directories (`upper/`, `work/`, `merged/`) that provide copy-on-write semantics. Guest writes land in `upper/`, leaving the shared cache untouched.
 - The `virtiofsd.sock` socket is the communication channel between Cloud Hypervisor and the virtiofsd daemon serving the merged filesystem.
 - The existing `cache/images/`, `cache/manifests/`, and `firmware/` directories are unchanged.
+
+`oci-runtime-refs.json` schema:
+
+```json
+{
+  "runtimes": {
+    "<runtimeKey>": {
+      "refs": ["vm-..."],
+      "created_at": "2026-02-19T00:00:00Z"
+    }
+  }
+}
+```
 
 ### 8.1 OCI Cache Lifecycle and Garbage Collection
 
@@ -782,16 +804,19 @@ This section separates OCI build-cache GC behavior from OCI runtime-cache GC beh
 
 - `cocoon image build` stores blobs in `cache/oci/blobs/sha256/` and layouts in `cache/oci/layouts/{sha256-hex}/`.
 - Tag ownership is tracked in `db/oci-build-tags.json`; blob-to-manifest references are tracked in `db/oci-layer-refs.json`.
-- `cocoon gc` already includes OCI phases:
-  - remove orphaned layouts not referenced by `oci-build-tags.json`
-  - remove unreferenced blobs with zero refs in `oci-layer-refs.json`
-- GC uses `gc.lock` plus OCI index locks (`oci-build-tags.lock`, `oci-layer-refs.lock`) and a grace period to avoid races with in-progress builds.
+- `cocoon gc` includes 9 phases; OCI-related phases are:
+  - Phase 3: `CollectOrphanedOCILayouts`
+  - Phase 4: `CollectStaleOCITags`
+  - Phase 5: `CollectOrphanedOCIManifestRefs`
+  - Phase 6: `CollectUnreferencedOCIBlobs`
+  - Phase 7: `CollectUnreferencedOCIRuntimeCaches`
+- GC uses `gc.lock` plus OCI index locks (`oci-build-tags.lock`, `oci-layer-refs.lock`, `oci-runtime-refs.lock`) and a grace period to avoid races with in-progress builds.
 
 **Implemented (direct-kernel runtime path):**
 
 | Object | Location | Lifetime | Shared? |
 |--------|----------|----------|---------|
-| OCI runtime pull/extract cache | `cache/oci/{manifest-digest}/` (kernel, initrd, rootfs, custom dirs) | Persists until all referencing VMs are deleted and GC runs | Yes, across all VMs from the same OCI image |
+| OCI runtime cache | `cache/oci/runtime/{runtimeKey}/` (kernel/, rootfs/) | Persists until all referencing VMs are deleted and GC runs | Yes, across all VMs from the same OCI manifest |
 | Per-VM OverlayFS upperdir | `vms/{vm-id}/upper/` | VM lifetime (create to delete) | No, per-VM |
 | Per-VM OverlayFS workdir | `vms/{vm-id}/work/` | VM lifetime (create to delete) | No, per-VM |
 | Per-VM OverlayFS mount | `vms/{vm-id}/merged/` | VM runtime (start to stop) | No, per-VM |

--- a/docs/05-storage-management.md
+++ b/docs/05-storage-management.md
@@ -3,7 +3,7 @@
 **Version**: 1.0
 **Status**: Implemented
 **Phase**: Phase 1
-**Last Updated**: 2026-02-18
+**Last Updated**: 2026-02-19
 
 ## Overview
 
@@ -29,7 +29,9 @@ Lock file paths are additionally documented in [06-concurrency.md](./06-concurre
 │   ├── oci-build-txn.lock                # flock for OCI cross-index txn serialization
 │   ├── oci-build-tags.lock               # flock for OCI build tag index updates
 │   ├── oci-layer-refs.json               # Blob digest → [manifest digests] reference tracking (GC)
-│   └── oci-layer-refs.lock               # flock for oci-layer-refs.json updates
+│   ├── oci-layer-refs.lock               # flock for oci-layer-refs.json updates
+│   ├── oci-runtime-refs.json             # OCI runtime cache pin index: runtimeKey -> [vm-id]
+│   └── oci-runtime-refs.lock             # flock for oci-runtime-refs.json updates
 ├── cache/
 │   ├── images/                           # Base qcow2 images (content-addressed)
 │   │   ├── {checksum_16}_{arch}.qcow2    # e.g., a1b2c3d4e5f6a7b8_amd64.qcow2
@@ -41,10 +43,15 @@ Lock file paths are additionally documented in [06-concurrency.md](./06-concurre
 │   │   └── {checksum_16}_{arch}.lock     # Per-image conversion lock
 │   └── oci/                              # OCI VM image build cache (shared blob store)
 │       ├── blobs/sha256/{hex}            # Shared content-addressed blob store
-│       └── layouts/{sha256-hex}/             # OCI layouts (keyed by full tag+manifest hash, blobs are hardlinks)
-│           ├── oci-layout
-│           ├── index.json
-│           └── blobs/sha256/{hex}        # Hardlinks to ../../blobs/sha256/{hex}
+│       ├── layouts/{sha256-hex}/         # OCI layouts (keyed by full tag+manifest hash, blobs are hardlinks)
+│       │   ├── oci-layout
+│       │   ├── index.json
+│       │   └── blobs/sha256/{hex}        # Hardlinks to ../../blobs/sha256/{hex}
+│       └── runtime/{runtimeKey}/         # Materialized OCI runtime cache entry
+│           ├── rootfs/                   # Flattened rootfs lowerdir for OverlayFS
+│           └── kernel/
+│               ├── vmlinuz
+│               └── initrd.img
 ├── buildah/                              # Buildah storage root
 ├── vms/
 │   ├── {vm-id}/                          # e.g., vm-01HXYZ.../
@@ -104,19 +111,16 @@ Phase 2 Planned Paths:
 │   │           ├── index.json
 │   │           └── blobs/sha256/{hex}          # Hardlinks to shared blob store
 │   │
-│   ├── OCI VM Image Pull Cache (docs/04.1-oci-vm-images.md) — Phase 2 Planned
+│   ├── OCI VM Runtime Cache (docs/04.1-oci-vm-images.md) — Implemented
 │   │   └── cache/oci/
-│   │       └── {manifest-digest}/              # Per-image extracted artifacts
-│   │           ├── manifest.json               # OCI manifest
-│   │           ├── config.json                 # OCI VM config blob (kernel cmdline, etc.)
-│   │           ├── vmlinuz                     # Extracted kernel (payload.kernel)
-│   │           ├── initrd.img                  # Extracted initrd (payload.initramfs)
-│   │           ├── rootfs/                     # Rootfs layer (extracted dir tree, read-only)
-│   │           ├── custom-1/                   # First customization layer (read-only, if present)
-│   │           └── custom-N/                   # Nth customization layer (read-only, if present)
+│   │       └── runtime/{runtimeKey}/           # Per-manifest materialized runtime artifacts
+│   │           ├── rootfs/                     # Runtime lowerdir served through OverlayFS
+│   │           └── kernel/
+│   │               ├── vmlinuz                 # payload.kernel
+│   │               └── initrd.img              # payload.initramfs
 │   │   └── db/
-│   │       ├── oci-references.json             # manifest-digest -> [vm-id] ref tracking
-│   │       └── oci-references.lock             # flock for oci-references.json updates
+│   │       ├── oci-runtime-refs.json           # runtimeKey -> [vm-id] pin tracking
+│   │       └── oci-runtime-refs.lock           # flock for oci-runtime-refs.json updates
 │   │
 │   ├── Per-VM OCI Rootfs State (docs/04.1-oci-vm-images.md)
 │   │   └── vms/{vm-id}/
@@ -187,8 +191,8 @@ Path notes:
 - **OCI build cache** uses a shared blob store (`cache/oci/blobs/sha256/`) with
   hardlink-based deduplication across OCI layouts (`cache/oci/layouts/`).
   Blob reference counts are tracked in `db/oci-layer-refs.json`.
-- **OCI pull cache** (Phase 2 planned) directories are keyed by manifest digest
-  (content-addressable) and shared across all VMs created from the same OCI image.
+- **OCI runtime cache** directories live under `cache/oci/runtime/{runtimeKey}` and
+  are shared across all VMs created from the same OCI manifest.
 - **Network namespace** files under `/run/cocoon/` are lost on reboot; the Start()
   flow transparently recreates them when needed (see docs/16 Section 2.4).
 
@@ -241,6 +245,11 @@ Other documents MUST reference these definitions rather than re-defining fields.
 | `state` | string | `"RUNNING"` | Current VM state |
 | `previous_state` | string | `"STARTING"` | State before last transition |
 | `process_pid` | int | `12345` | CH process PID (0 if not running) |
+| `hypervisor_binary` | string | `"cloud-hypervisor"` | Basename of hypervisor process used for liveness checks |
+| `virtiofsd_pid` | int | `45678` | Rootfs virtiofsd PID (OCI runtime VMs only; omitted when not running) |
+| `virtiofsd_socket` | string | `"/run/cocoon/vms/{vm_id}/virtiofsd.sock"` | Rootfs-serving virtiofsd socket path (OCI runtime VMs only) |
+| `virtiofsd_binary` | string | `"virtiofsd"` | Basename of virtiofsd process used for liveness checks |
+| `oci_overlay_mounted` | bool | `true` | Whether the per-VM OCI OverlayFS mount is currently active |
 | `boot_time` | string | `"2.3s"` | Duration string |
 | `last_boot_mode` | string | `"uefi"` | Actual boot mode used (`"uefi"` / `"direct"`) |
 | `last_firmware_path` | string | `"/var/lib/cocoon/firmware/CLOUDHV.fd"` | Actual firmware used (empty for direct kernel boot) |
@@ -353,6 +362,7 @@ type CocoonConfig struct {
 
     // Binaries and firmware
     CHBinary         string `json:"ch_binary"`           // Cloud Hypervisor binary
+    VirtiofsdBinary  string `json:"virtiofsd_binary"`    // virtiofsd binary (OCI runtime path)
     UEFIFirmwarePath string `json:"uefi_firmware_path"`  // UEFI firmware path
     BuildahRoot      string `json:"buildah_root"`        // Buildah storage root
 
@@ -392,16 +402,14 @@ func (c *CocoonConfig) OCILayerRefsLock() string   // RootDir/db/oci-layer-refs.
 
 // EnsureDirs creates all required directories (db, cache/images,
 // cache/manifests, cache/locks, cache/oci/blobs/sha256, cache/oci/layouts,
-// vms, temp, firmware, buildah, RuntimeDir/vms, LogDir).
+// cache/oci/runtime, vms, temp, firmware, buildah, RuntimeDir/vms, LogDir).
 func (c *CocoonConfig) EnsureDirs() error { ... }
 ```
 
-#### Phase 2 Planned Path Helpers
+#### Phase 2 Path Helpers
 
-The following path helpers are planned for Phase 2 features. They are not yet
-implemented but are documented here to reserve the namespace and ensure
-consistency across design documents. See the Phase 2 tree diagram above for
-the full directory layout.
+The following path helpers are used by implemented and planned Phase 2
+features. See the Phase 2 tree diagram above for the full directory layout.
 
 ```go
 // Phase 2 — Warm Start (docs/15-warm-start.md)
@@ -422,7 +430,13 @@ func (c *CocoonConfig) OCILayerRefsFile() string                    // RootDir/d
 func (c *CocoonConfig) OCILayerRefsLock() string                    // RootDir/db/oci-layer-refs.lock
 
 // OCI VM Boot (docs/04.1-oci-vm-images.md) — Implemented
-func (c *CocoonConfig) OCICacheEntry(digest string) string                // RootDir/cache/oci/{digest}
+func (c *CocoonConfig) OCIRuntimeCacheDir() string                        // RootDir/cache/oci/runtime
+func (c *CocoonConfig) OCIRuntimeEntryDir(runtimeKey string) string       // RootDir/cache/oci/runtime/{runtimeKey}
+func (c *CocoonConfig) OCIRuntimeRootfsDir(runtimeKey string) string      // RootDir/cache/oci/runtime/{runtimeKey}/rootfs
+func (c *CocoonConfig) OCIRuntimeKernelPath(runtimeKey string) string     // RootDir/cache/oci/runtime/{runtimeKey}/kernel/vmlinuz
+func (c *CocoonConfig) OCIRuntimeInitrdPath(runtimeKey string) string     // RootDir/cache/oci/runtime/{runtimeKey}/kernel/initrd.img
+func (c *CocoonConfig) OCIRuntimeRefsFile() string                        // RootDir/db/oci-runtime-refs.json
+func (c *CocoonConfig) OCIRuntimeRefsLock() string                        // RootDir/db/oci-runtime-refs.lock
 func (c *CocoonConfig) VMOCIUpperDir(vmID string) string                  // RootDir/vms/{vmID}/upper
 func (c *CocoonConfig) VMOCIWorkDir(vmID string) string                   // RootDir/vms/{vmID}/work
 func (c *CocoonConfig) VMOCIMergedDir(vmID string) string                 // RootDir/vms/{vmID}/merged
@@ -440,7 +454,7 @@ func (c *CocoonConfig) SharesDir() string                            // RootDir/
 ```
 
 `EnsureDirs()` already creates `RootDir/cache/oci/blobs/sha256` and
-`RootDir/cache/oci/layouts` at startup. It will be extended to create
+`RootDir/cache/oci/layouts` and `RootDir/cache/oci/runtime` at startup. It will be extended to create
 `RootDir/checkpoints` and `RootDir/shares` at startup. `RootDir/dnsmasq`
 is created when the first networked VM is provisioned. Per-VM directories
 (`checkpoints/{ckptID}`, `vms/{vmID}/upper`, `vms/{vmID}/work`,
@@ -743,6 +757,11 @@ func (gc *fileGarbageCollector) CollectOrphanedOCIManifestRefs() ([]string, erro
 // Lock: gc.lock (L1) -> oci-layer-refs.lock for atomic check-and-delete.
 func (gc *fileGarbageCollector) CollectUnreferencedOCIBlobs() ([]string, error) { ... }
 
+// CollectUnreferencedOCIRuntimeCaches removes runtime cache entries in
+// cache/oci/runtime/ that have no VM pins in oci-runtime-refs.json.
+// Lock: gc.lock (L1) -> oci-runtime-refs.lock.
+func (gc *fileGarbageCollector) CollectUnreferencedOCIRuntimeCaches() ([]string, error) { ... }
+
 // CollectStaleConversionLocks removes stale conversion lock files from
 // cache/locks/ where the corresponding base image no longer exists and
 // the lock is not currently held.
@@ -766,6 +785,7 @@ func (gc *fileGarbageCollector) FullGC() error {
     gc.CollectStaleOCITags()
     gc.CollectOrphanedOCIManifestRefs()
     gc.CollectUnreferencedOCIBlobs()
+    gc.CollectUnreferencedOCIRuntimeCaches()
     gc.CollectStaleConversionLocks(lockMaxAge)
     gc.CollectTempFiles(tempMaxAge)
     return nil
@@ -782,7 +802,12 @@ GC operations must coordinate with concurrent VM create/delete operations. See [
 - Lock ordering to prevent deadlocks with VM operations
 - Crash recovery and lock auto-release
 
-**OCI lock note**: `oci-layer-refs.lock` is a Level 2 lock, at the same level as `references.lock`. These two locks protect different files and are never held simultaneously. During OCI GC phases, the lock acquisition order is: `gc.lock` (L1) -> `oci-build-txn.lock` -> `oci-build-tags.lock` / `oci-layer-refs.lock` (L2), which respects the hierarchy.
+**OCI lock note**: `oci-layer-refs.lock` and `oci-runtime-refs.lock` are Level 2 locks (same level as `references.lock`). During OCI GC phases, lock acquisition order is:
+
+- Build/index phases: `gc.lock` (L1) -> `oci-build-txn.lock` -> `oci-build-tags.lock` -> `oci-layer-refs.lock`
+- Runtime cache phase: `gc.lock` (L1) -> `oci-runtime-refs.lock`
+
+The runtime-refs lock is intentionally disjoint from tag/layer-refs locks to avoid deadlocks.
 
 **Key guarantee**: GC cannot delete a base image while any VM references it, even under high concurrency or process crashes.
 
@@ -846,7 +871,17 @@ Blobs in `cache/oci/blobs/sha256/` with zero manifest references in `oci-layer-r
 
 **Locking**: GC lock (L1) followed by `oci-layer-refs.lock` for atomic check-and-delete.
 
-#### 7. Stale Conversion Locks
+#### 7. Unreferenced OCI Runtime Caches
+
+Runtime cache directories under `cache/oci/runtime/` with no active VM pins in `oci-runtime-refs.json`.
+
+**Detection:** Runtime directory exists but either has no entry in `oci-runtime-refs.json` or has an entry with an empty `refs` array.
+
+**Action:** Remove the runtime cache directory and prune stale zero-ref entries from `oci-runtime-refs.json`.
+
+**Locking**: GC lock (L1) followed by `oci-runtime-refs.lock`.
+
+#### 8. Stale Conversion Locks
 
 Lock files in `cache/locks/` left behind after image deletion. These are best-effort hygiene to clean lock files that are no longer needed.
 
@@ -856,7 +891,7 @@ Lock files in `cache/locks/` left behind after image deletion. These are best-ef
 
 **Locking**: GC lock (L1) only. Active lock files are preserved.
 
-#### 8. Temporary Entries
+#### 9. Temporary Entries
 
 Files/directories in the `/var/lib/cocoon/temp/` directory older than a threshold (default: 1 hour).
 
@@ -872,6 +907,7 @@ OCI resources use a 5-minute defense-in-depth grace period to prevent races with
 
 - OCI layouts (Phase 3)
 - OCI blobs (Phase 5, 6)
+- OCI runtime cache entries (Phase 7)
 
 Temp entries use a 1-hour max age (hardcoded in `FullGC()`).
 

--- a/docs/09-cli-design.md
+++ b/docs/09-cli-design.md
@@ -1597,16 +1597,31 @@ func doctorAction(c *cli.Context) error {
 - guestfish binary (minimum `1.50.0`)
 - swtpm binary (TPM 2.0 emulator)
 - virt-customize binary (optional; required for Cocoonfile RUN/COPY steps)
+- overlayfs availability check (Linux OCI runtime path prerequisite)
+- virtiofsd binary (minimum `1.7.0`, required for OCI runtime path)
 - /dev/kvm device
 - Directory structure (root, runtime, log, db, vm, cache, buildah, firmware)
+- OCI blob-ref cleanup diagnostic counter (`oci/blob-ref-cleanup`)
 
-**VM Reconciliation** (--fix repairs these):
-- Stale RUNNING state (CH process not found → mark ERROR)
-- Zombie socket / stale PID file → remove
-- Orphaned overlay (overlay exists, config missing) → permanently delete VM dir
-- Missing reference (config exists, references missing vmID) → restore `references.json` entry
-- Dangling reference (references vmID missing/mismatched config) → remove stale vmID from `references.json`
-- Name index inconsistencies → detect in dry-run, rebuild only with `--fix`
+**VM Reconciliation types** (`vm.InconsistencyType`, `--fix` repairs when supported):
+- `state_mismatch` (metadata state does not match probed runtime state)
+- `metadata_corrupted` (metadata.json unreadable or invalid)
+- `stale_pid_file` (PID file points to non-running process)
+- `zombie_socket` (runtime socket exists without a valid process)
+- `zombie_process` (process exists but VM state/files are inconsistent)
+- `missing_overlay` (config exists but overlay.qcow2 missing)
+- `orphaned_overlay` (overlay exists but config missing)
+- `oci_runtime_cache_missing` (OCI runtime cache entry missing for an OCI VM)
+- `oci_runtime_overlay_mismatch` (OCI overlay mount state mismatch)
+- `oci_runtime_virtiofsd_mismatch` (virtiofsd state mismatch for OCI runtime)
+- `missing_oci_runtime_pin` (VM missing runtime pin in `oci-runtime-refs.json`)
+- `dangling_oci_runtime_pin` (runtime pin references non-existent VM)
+- `orphaned_oci_runtime_cache` (runtime cache entry exists but no owning VM)
+- `missing_reference` (config exists but `references.json` missing vmID)
+- `dangling_reference` (reference entry points to missing/mismatched VM)
+- `name_index_stale` (name-index drift vs persisted configs)
+- `duplicate_vm_name` (duplicate VM names detected in persisted configs)
+- `deleted_vm_directory` (name-index entry points to missing VM directory)
 
 **Exit Codes**:
 - `0`: All checks passed (returns nil)
@@ -2190,10 +2205,14 @@ This CLI design implements the Boot Contract specification:
 **Policy**: Regular CLI commands (`start`, `stop`, `delete`, `list`, `inspect`, etc.) do **not** perform automatic reconciliation. They operate on the recorded state in `metadata.json` and trust that state reflects reality.
 
 **`cocoon doctor`** is the sole entry point for reconciliation:
-- Scans all VM directories for stale state (e.g., metadata says RUNNING but CH process is dead)
-- Cleans up orphaned sockets and stale PID files
-- Fixes metadata inconsistencies (transitions stale RUNNING → ERROR)
-- Checks name index drift in dry-run mode; rebuilds name index only with `cocoon doctor --fix`
+- Detects the full inconsistency set defined in `vm/types.go`:
+  - `state_mismatch`, `metadata_corrupted`, `stale_pid_file`, `zombie_socket`, `zombie_process`
+  - `missing_overlay`, `orphaned_overlay`
+  - `oci_runtime_cache_missing`, `oci_runtime_overlay_mismatch`, `oci_runtime_virtiofsd_mismatch`
+  - `missing_oci_runtime_pin`, `dangling_oci_runtime_pin`, `orphaned_oci_runtime_cache`
+  - `missing_reference`, `dangling_reference`
+  - `name_index_stale`, `duplicate_vm_name`, `deleted_vm_directory`
+- Applies supported remediations only when `cocoon doctor --fix` is provided.
 
 **Rationale**: Auto-reconcile on every command adds latency and complexity. Users who suspect state drift run `cocoon doctor` explicitly. This is the same pattern used by containerd and other container runtimes.
 

--- a/oci/login.go
+++ b/oci/login.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 
 	cflock "github.com/CMGS/cocoon/lock/flock"
+	"github.com/CMGS/cocoon/utils"
 )
 
 const registryHTTPTimeout = 30 * time.Second
@@ -119,13 +120,8 @@ func Login(ctx context.Context, registry, username, password string) error {
 		return fmt.Errorf("marshal config: %w", err)
 	}
 
-	tmpFile := configPath + ".tmp"
-	if err := os.WriteFile(tmpFile, append(data, '\n'), 0o600); err != nil {
+	if err := utils.AtomicWriteFile(configPath, append(data, '\n'), 0o600); err != nil {
 		return fmt.Errorf("write config: %w", err)
-	}
-	if err := os.Rename(tmpFile, configPath); err != nil {
-		os.Remove(tmpFile) //nolint:errcheck,gosec // G104: best-effort cleanup
-		return fmt.Errorf("rename config: %w", err)
 	}
 
 	return nil

--- a/oci/runtime_refs.go
+++ b/oci/runtime_refs.go
@@ -26,6 +26,7 @@ type RuntimeRefsIndex struct {
 // AddRuntimeRef pins vmID to a runtimeKey.
 // Idempotent: adding the same vmID twice does not duplicate refs.
 func AddRuntimeRef(cfg *config.CocoonConfig, runtimeKey, vmID string) error {
+	runtimeKey = strings.TrimSpace(runtimeKey)
 	if err := validateRuntimeKey(runtimeKey); err != nil {
 		return err
 	}
@@ -54,6 +55,7 @@ func AddRuntimeRef(cfg *config.CocoonConfig, runtimeKey, vmID string) error {
 // RemoveRuntimeRef unpins vmID from runtimeKey.
 // If the last ref is removed the runtimeKey entry is deleted.
 func RemoveRuntimeRef(cfg *config.CocoonConfig, runtimeKey, vmID string) error {
+	runtimeKey = strings.TrimSpace(runtimeKey)
 	if err := validateRuntimeKey(runtimeKey); err != nil {
 		return err
 	}
@@ -88,6 +90,7 @@ func RemoveRuntimeRef(cfg *config.CocoonConfig, runtimeKey, vmID string) error {
 
 // GetRuntimeRefs returns VM IDs currently pinning runtimeKey.
 func GetRuntimeRefs(cfg *config.CocoonConfig, runtimeKey string) ([]string, error) {
+	runtimeKey = strings.TrimSpace(runtimeKey)
 	if err := validateRuntimeKey(runtimeKey); err != nil {
 		return nil, err
 	}

--- a/oci/runtime_refs_test.go
+++ b/oci/runtime_refs_test.go
@@ -86,3 +86,34 @@ func TestRuntimeRefs_InvalidRuntimeKey(t *testing.T) {
 		t.Fatal("expected invalid runtime key error, got nil")
 	}
 }
+
+func TestRuntimeRefs_RuntimeKeyIsTrimmedBeforeIndexing(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	key := "0011223344556677"
+	vmID := "vm-01HF00TESTTRIM0000000000"
+
+	if err := AddRuntimeRef(cfg, "  "+key+"  ", vmID); err != nil {
+		t.Fatalf("AddRuntimeRef: %v", err)
+	}
+
+	refs, err := GetRuntimeRefs(cfg, key)
+	if err != nil {
+		t.Fatalf("GetRuntimeRefs: %v", err)
+	}
+	if len(refs) != 1 || refs[0] != vmID {
+		t.Fatalf("refs=%v, want [%s]", refs, vmID)
+	}
+
+	if err := RemoveRuntimeRef(cfg, "\t"+key+"\n", vmID); err != nil {
+		t.Fatalf("RemoveRuntimeRef: %v", err)
+	}
+	refs, err = GetRuntimeRefs(cfg, key)
+	if err != nil {
+		t.Fatalf("GetRuntimeRefs after remove: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Fatalf("refs after remove=%v, want []", refs)
+	}
+}

--- a/storage/local/gc_oci.go
+++ b/storage/local/gc_oci.go
@@ -15,6 +15,17 @@ import (
 // ociGCGracePeriod is an alias for the canonical constant in the storage package.
 const ociGCGracePeriod = storage.OCIGCGracePeriod
 
+// OCI GC lock hierarchy (must remain consistent with docs/06-concurrency.md):
+// 1. gc.lock (L1) is always outermost for all GC phases.
+// 2. Build/index phases then acquire:
+//   - oci-build-txn.lock
+//   - oci-build-tags.lock
+//   - oci-layer-refs.lock
+// 3. Runtime cache phases acquire:
+//   - oci-runtime-refs.lock
+// Never acquire oci-runtime-refs.lock while holding oci-build-tags.lock or
+// oci-layer-refs.lock.
+
 // CollectOrphanedOCILayouts removes OCI layout directories in cache/oci/layouts/
 // that are not referenced by any tag in oci-build-tags.json.
 //

--- a/utils/atomic.go
+++ b/utils/atomic.go
@@ -2,9 +2,11 @@ package utils
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 // AtomicWriteFile writes data to a file atomically using temp + fsync + rename.
@@ -44,6 +46,9 @@ func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	if err = os.Rename(tmpPath, path); err != nil {
 		return fmt.Errorf("rename temp to target: %w", err)
 	}
+	if err = syncParentDir(dir); err != nil {
+		return fmt.Errorf("sync parent dir: %w", err)
+	}
 	return nil
 }
 
@@ -64,4 +69,21 @@ func ReadJSON(path string, v any) error {
 		return err
 	}
 	return json.Unmarshal(data, v)
+}
+
+func syncParentDir(dir string) error {
+	parent, err := os.Open(dir) //nolint:gosec // directory is derived from cocoon-managed target path
+	if err != nil {
+		return err
+	}
+	defer parent.Close() //nolint:errcheck
+
+	if err := parent.Sync(); err != nil {
+		// Some filesystems or platforms may not support directory fsync.
+		if errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.ENOTSUP) || errors.Is(err, syscall.EBADF) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }

--- a/vm/engine/oci_runtime_prepare.go
+++ b/vm/engine/oci_runtime_prepare.go
@@ -121,7 +121,9 @@ func materializeOCIRuntimeCache(ctx context.Context, cfg *config.CocoonConfig, r
 	if err = os.MkdirAll(cfg.OCIRuntimeCacheDir(), 0o755); err != nil { //nolint:gosec // cocoon-managed cache dir
 		return fmt.Errorf("create OCI runtime cache dir: %w", err)
 	}
-	workDir, err := os.MkdirTemp(cfg.TempDir(), "oci-runtime-"+runtimeKey+"-*")
+	// Build the workspace under OCIRuntimeCacheDir so directory promotions stay
+	// on the same filesystem and os.Rename remains atomic.
+	workDir, err := os.MkdirTemp(cfg.OCIRuntimeCacheDir(), runtimeKey+"-work-*")
 	if err != nil {
 		return fmt.Errorf("create OCI runtime temp dir: %w", err)
 	}
@@ -157,19 +159,44 @@ func materializeOCIRuntimeCache(ctx context.Context, cfg *config.CocoonConfig, r
 		return err
 	}
 
-	finalDir := cfg.OCIRuntimeEntryDir(runtimeKey)
-	_ = os.RemoveAll(finalDir)
-	// Callers must go through prepareLocalOCIRuntime(), which holds both the
-	// txn lock and per-runtime lock. That contract prevents concurrent readers
-	// from observing a half-updated runtime entry between RemoveAll and Rename.
-	// Crash note: RemoveAll + Rename is not a single atomic operation. If the
-	// process crashes in between, the runtime entry can be temporarily missing.
-	// This is tolerated because subsequent starts re-materialize the cache.
-	// Atomic promotion assumes TempDir and OCIRuntimeCacheDir share a filesystem.
-	// Current defaults are both under RootDir. If callers customize these to
-	// different mount points, rename will fail with EXDEV and return an error.
-	if err := os.Rename(workDir, finalDir); err != nil {
+	if err := promoteOCIRuntimeCacheDir(workDir, cfg.OCIRuntimeEntryDir(runtimeKey)); err != nil {
 		return fmt.Errorf("promote OCI runtime cache %s: %w", runtimeKey, err)
+	}
+	return nil
+}
+
+func promoteOCIRuntimeCacheDir(workDir, finalDir string) error {
+	finalDir = filepath.Clean(finalDir)
+	newDir := finalDir + ".new"
+	oldDir := finalDir + ".old"
+
+	// Best-effort cleanup from a prior interrupted promotion.
+	_ = os.RemoveAll(newDir)
+	_ = os.RemoveAll(oldDir)
+
+	if err := os.Rename(workDir, newDir); err != nil {
+		return fmt.Errorf("stage new OCI runtime cache: %w", err)
+	}
+
+	hadOld := false
+	if err := os.Rename(finalDir, oldDir); err == nil {
+		hadOld = true
+	} else if !os.IsNotExist(err) {
+		_ = os.RemoveAll(newDir)
+		return fmt.Errorf("rotate existing OCI runtime cache: %w", err)
+	}
+
+	if err := os.Rename(newDir, finalDir); err != nil {
+		// Best-effort rollback to keep the previous runtime cache available.
+		if hadOld {
+			_ = os.Rename(oldDir, finalDir)
+		}
+		return fmt.Errorf("activate new OCI runtime cache: %w", err)
+	}
+
+	// Best-effort cleanup; stale .old directories are harmless and can be GC'd.
+	if hadOld {
+		_ = os.RemoveAll(oldDir)
 	}
 	return nil
 }

--- a/vm/engine/oci_runtime_prepare_test.go
+++ b/vm/engine/oci_runtime_prepare_test.go
@@ -1,0 +1,74 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPromoteOCIRuntimeCacheDir_NewEntry(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	finalDir := filepath.Join(baseDir, "runtime", "abc123")
+	workDir := filepath.Join(baseDir, "work-new")
+	if err := os.MkdirAll(filepath.Join(workDir, "rootfs"), 0o755); err != nil { //nolint:gosec // test workspace
+		t.Fatalf("mkdir work rootfs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "rootfs", "marker"), []byte("new"), 0o644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(finalDir), 0o755); err != nil { //nolint:gosec // test workspace
+		t.Fatalf("mkdir final parent: %v", err)
+	}
+	if err := promoteOCIRuntimeCacheDir(workDir, finalDir); err != nil {
+		t.Fatalf("promoteOCIRuntimeCacheDir: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(finalDir, "rootfs", "marker")); err != nil {
+		t.Fatalf("expected promoted rootfs marker: %v", err)
+	}
+	if _, err := os.Stat(finalDir + ".new"); !os.IsNotExist(err) {
+		t.Fatalf("expected no .new dir, err=%v", err)
+	}
+	if _, err := os.Stat(finalDir + ".old"); !os.IsNotExist(err) {
+		t.Fatalf("expected no .old dir, err=%v", err)
+	}
+}
+
+func TestPromoteOCIRuntimeCacheDir_RotatesExistingEntry(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	finalDir := filepath.Join(baseDir, "runtime", "abc123")
+	if err := os.MkdirAll(filepath.Join(finalDir, "rootfs"), 0o755); err != nil { //nolint:gosec // test workspace
+		t.Fatalf("mkdir final rootfs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(finalDir, "rootfs", "marker"), []byte("old"), 0o644); err != nil {
+		t.Fatalf("write old marker: %v", err)
+	}
+
+	workDir := filepath.Join(baseDir, "work-new")
+	if err := os.MkdirAll(filepath.Join(workDir, "rootfs"), 0o755); err != nil { //nolint:gosec // test workspace
+		t.Fatalf("mkdir work rootfs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "rootfs", "marker"), []byte("new"), 0o644); err != nil {
+		t.Fatalf("write new marker: %v", err)
+	}
+
+	if err := promoteOCIRuntimeCacheDir(workDir, finalDir); err != nil {
+		t.Fatalf("promoteOCIRuntimeCacheDir: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(finalDir, "rootfs", "marker"))
+	if err != nil {
+		t.Fatalf("read promoted marker: %v", err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("marker=%q, want %q", string(got), "new")
+	}
+	if _, err := os.Stat(finalDir + ".old"); !os.IsNotExist(err) {
+		t.Fatalf("expected no .old dir, err=%v", err)
+	}
+}


### PR DESCRIPTION
## Summary
This PR implements the remaining code and documentation fixes tracked in #23 after the post-Phase-2 review.

## Scope
### Code
- `vm/engine/oci_runtime_prepare.go`
  - Replace `RemoveAll+Rename` promotion with a rotate promotion (`.new`/`.old`) and add unit tests.
  - Materialize temporary runtime workspace under `cache/oci/runtime` so promotion stays same-filesystem.
- `utils/atomic.go`
  - Add parent-directory `fsync` after rename in `AtomicWriteFile`.
- `cmd/cocoon/doctor.go`
  - Surface `oci.BlobRefCleanupFailureCount()` as `oci/blob-ref-cleanup` health check.
- `oci/runtime_refs.go`
  - Trim `runtimeKey` before map/index usage in Add/Remove/Get.
  - Add trim behavior test coverage.
- `storage/local/gc_oci.go`
  - Add explicit OCI GC lock hierarchy note including runtime refs lock.
- `oci/login.go`
  - Replace fixed `.tmp` credential write path with `utils.AtomicWriteFile` (CreateTemp-based atomic write).

### Docs
- `docs/05-storage-management.md`
  - Add runtime cache + runtime refs files to canonical layout.
  - Sync config/metadata/path helper listings with implemented fields and helpers.
  - Update EnsureDirs and FullGC pseudocode to include runtime cache phase (9 total phases).
  - Add OCI runtime cache collection category and lock-order notes.
- `docs/04.1-oci-vm-images.md`
  - Sync storage tree and CH payload paths to `cache/oci/runtime/{runtimeKey}`.
  - Document `oci-runtime-refs.json` schema.
  - Update GC phase description to include runtime cache collection.
- `docs/09-cli-design.md`
  - Add doctor checks for overlayfs and virtiofsd.
  - Add complete 18 reconcile inconsistency types.
- `AGENTS.md`
  - Add `security:` inline-review severity prefix.

## Validation
- `make lint`
- `make test`

## Risk Notes
- Runtime cache promotion now has rollback behavior and narrower absent-window semantics.
- Atomic file writes now may return on hard directory-sync errors (except known unsupported directory fsync errors), which is safer for persistence guarantees.

Closes #23
