### PR TITLE
feat(cli): support multi-object image remove/rm

### DIFF
--- a/cmd/cocoon/images.go
+++ b/cmd/cocoon/images.go
@@ -679,15 +679,15 @@ func imageRemoveCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "remove",
 		Aliases:   []string{"rm"},
-		Usage:     "Remove a cached image (only if unreferenced)",
-		ArgsUsage: "IMAGE_REF",
+		Usage:     "Remove one or more cached images (only if unreferenced)",
+		ArgsUsage: "IMAGE_REF [IMAGE_REF...]",
 		Action:    imageRemoveAction,
 	}
 }
 
 func imageRemoveAction(c *cli.Context) error {
 	if c.NArg() < 1 {
-		return fmt.Errorf("IMAGE_REF argument required\n\nUsage: cocoon image remove IMAGE_REF")
+		return fmt.Errorf("IMAGE_REF argument required\n\nUsage: cocoon image remove IMAGE_REF [IMAGE_REF...]")
 	}
 
 	app, err := initApp(c)
@@ -695,8 +695,24 @@ func imageRemoveAction(c *cli.Context) error {
 		return err
 	}
 
-	ref := c.Args().Get(0)
+	var errs []string
+	removed := 0
+	for i := 0; i < c.NArg(); i++ {
+		ref := c.Args().Get(i)
+		if rmErr := removeOneImage(c, app, ref); rmErr != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", ref, rmErr))
+			continue
+		}
+		removed++
+	}
 
+	if len(errs) > 0 {
+		return fmt.Errorf("removed %d of %d image(s); %d failed:\n  %s", removed, c.NArg(), len(errs), strings.Join(errs, "\n  "))
+	}
+	return nil
+}
+
+func removeOneImage(c *cli.Context, app *appContext, ref string) error {
 	// Try OCI image removal first.
 	// Use tag-index existence instead of ResolveTag so we can clean stale tags
 	// even when the layout directory has already been deleted.


### PR DESCRIPTION
## Summary
- Add multi-object support to `cocoon image remove/rm`
- `cocoon image rm img1 img2 img3` now removes multiple images in one invocation
- Errors per-item are collected without aborting on first failure
- Reports "removed N of M" summary on partial failure

## Audit Results
| Command | Multi-object before | Multi-object after |
|---------|--------------------|--------------------|
| `cocoon delete/rm VM [VM...]` | Already supported | No change |
| `cocoon image remove/rm IMG [IMG...]` | Single only | Now supported |

## Changes
- `cmd/cocoon/images.go`: Refactored `imageRemoveAction` to loop over all args, extracted `removeOneImage` helper
- Updated `ArgsUsage` to `IMAGE_REF [IMAGE_REF...]`
- Updated usage error message

## Test plan
- [x] `make fmt` -- 0 issues
- [x] `make lint` (linux + darwin) -- 0 issues
- [x] `go test ./cmd/cocoon/...` -- pass
