### PR TITLE
feat: add virtiofs module check to image verify for OCI VM images

### DIFF
--- a/cmd/cocoon/images.go
+++ b/cmd/cocoon/images.go
@@ -926,7 +926,57 @@ func verifyOCILayoutBootability(layoutPath string) (*image.BootCheckResult, erro
 	if err != nil {
 		return nil, fmt.Errorf("inspect OCI layout: %w", err)
 	}
-	return evaluateOCILayoutBootability(info), nil
+	result := evaluateOCILayoutBootability(info)
+	checkInitramfsVirtiofs(result, info, layoutPath)
+	return result, nil
+}
+
+// checkInitramfsVirtiofs inspects the kernel layer initramfs for virtiofs
+// module support. If the kernel layer is present, it locates the blob on
+// disk, reads the initrd entry from the tar, and scans the cpio archive
+// for virtiofs.ko. The result is reported as VirtiofsChecked/VirtiofsFound
+// fields plus a PASS or WARN message in the verify output.
+func checkInitramfsVirtiofs(result *image.BootCheckResult, info *oci.LayoutInfo, layoutPath string) {
+	if info == nil {
+		return
+	}
+
+	// Find the kernel layer digest.
+	var kernelDigest string
+	for _, layer := range info.Layers {
+		if layer.MediaType == oci.MediaTypeKernelLayer {
+			kernelDigest = layer.Digest
+			break
+		}
+	}
+	if kernelDigest == "" {
+		// No kernel layer; virtiofs check is not applicable.
+		return
+	}
+
+	blobPath, err := oci.LayoutBlobPath(layoutPath, kernelDigest)
+	if err != nil {
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("virtiofs check skipped: resolve kernel layer blob: %v", err))
+		return
+	}
+
+	found, checkErr := oci.CheckInitramfsVirtiofs(blobPath)
+	if checkErr != nil {
+		result.VirtiofsChecked = false
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("virtiofs check inconclusive: %v", checkErr))
+		return
+	}
+
+	result.VirtiofsChecked = true
+	result.VirtiofsFound = found
+	if found {
+		result.Warnings = append(result.Warnings, "virtiofs module found in initramfs")
+	} else {
+		result.Warnings = append(result.Warnings,
+			"virtiofs module not found in initramfs \u2014 OCI VM direct boot may fail if stock initramfs lacks virtiofs support")
+	}
 }
 
 func evaluateOCILayoutBootability(info *oci.LayoutInfo) *image.BootCheckResult {

--- a/cmd/cocoon/images_test.go
+++ b/cmd/cocoon/images_test.go
@@ -146,6 +146,68 @@ func TestEvaluateOCILayoutBootability_MissingKernelLayer(t *testing.T) {
 	}
 }
 
+func TestCheckInitramfsVirtiofs_NoKernelLayer(t *testing.T) {
+	t.Parallel()
+
+	// When there is no kernel layer, checkInitramfsVirtiofs should be a no-op.
+	info := &oci.LayoutInfo{
+		Layers: []oci.LayerInfo{
+			{MediaType: oci.MediaTypeRootfsLayer},
+		},
+		Config: &oci.VMImageConfig{},
+	}
+	result := evaluateOCILayoutBootability(info)
+	checkInitramfsVirtiofs(result, info, "/nonexistent")
+
+	if result.VirtiofsChecked {
+		t.Fatal("VirtiofsChecked should be false when no kernel layer present")
+	}
+	if result.VirtiofsFound {
+		t.Fatal("VirtiofsFound should be false when no kernel layer present")
+	}
+}
+
+func TestCheckInitramfsVirtiofs_NilInfo(t *testing.T) {
+	t.Parallel()
+
+	result := &image.BootCheckResult{
+		Warnings: []string{},
+	}
+	// Should not panic on nil info.
+	checkInitramfsVirtiofs(result, nil, "/nonexistent")
+	if result.VirtiofsChecked || result.VirtiofsFound {
+		t.Fatal("virtiofs fields should remain false for nil info")
+	}
+}
+
+func TestCheckInitramfsVirtiofs_BadBlobPath(t *testing.T) {
+	t.Parallel()
+
+	info := &oci.LayoutInfo{
+		Layers: []oci.LayerInfo{
+			{MediaType: oci.MediaTypeKernelLayer, Digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+		},
+		Config: &oci.VMImageConfig{},
+	}
+	result := evaluateOCILayoutBootability(info)
+	// layoutPath does not exist, so the blob cannot be found.
+	checkInitramfsVirtiofs(result, info, "/nonexistent-layout-path")
+
+	if result.VirtiofsChecked {
+		t.Fatal("VirtiofsChecked should be false when blob cannot be read")
+	}
+	foundWarning := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "virtiofs check") {
+			foundWarning = true
+			break
+		}
+	}
+	if !foundWarning {
+		t.Fatalf("expected a virtiofs warning, got warnings: %v", result.Warnings)
+	}
+}
+
 func TestEnsureLatestTag(t *testing.T) {
 	t.Parallel()
 

--- a/image/types.go
+++ b/image/types.go
@@ -120,6 +120,12 @@ type BootCheckResult struct {
 	BootloaderFound bool `json:"bootloader_found"`
 	// BootloaderChecked indicates the bootloader check completed.
 	BootloaderChecked bool `json:"bootloader_checked"`
+
+	// VirtiofsFound indicates whether the virtiofs kernel module was found
+	// inside the initramfs of an OCI VM kernel layer.
+	VirtiofsFound bool `json:"virtiofs_found"`
+	// VirtiofsChecked indicates the virtiofs module check completed.
+	VirtiofsChecked bool `json:"virtiofs_checked"`
 }
 
 // CachedImage describes a base image stored in the image cache.

--- a/oci/initramfs.go
+++ b/oci/initramfs.go
@@ -1,0 +1,235 @@
+package oci
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+)
+
+// initrdEntryNames lists the tar entry names used for the initramfs inside
+// the kernel layer tar. The build pipeline uses "initrd.img"; other names
+// are checked for forward compatibility.
+var initrdEntryNames = []string{
+	"initrd.img",
+	"initrd",
+	"initramfs.img",
+	"initramfs",
+}
+
+// CheckInitramfsVirtiofs opens the kernel layer tar at layerBlobPath, locates
+// the initramfs entry, decompresses it (gzip or uncompressed cpio), and scans
+// the cpio archive for any entry whose path contains "virtiofs.ko".
+//
+// It returns (found, error). When the initramfs cannot be located or read,
+// it returns (false, err) so the caller can decide whether to treat the
+// failure as a warning or an error.
+func CheckInitramfsVirtiofs(layerBlobPath string) (bool, error) {
+	f, err := os.Open(layerBlobPath) //nolint:gosec // G304: path is from local OCI layout
+	if err != nil {
+		return false, fmt.Errorf("open kernel layer blob: %w", err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	tr := tar.NewReader(f)
+	for {
+		hdr, readErr := tr.Next()
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return false, fmt.Errorf("read kernel layer tar: %w", readErr)
+		}
+		if !isInitrdEntry(hdr.Name) {
+			continue
+		}
+
+		// Found the initramfs entry. Read it fully so we can inspect it.
+		initrdData, readAllErr := io.ReadAll(tr)
+		if readAllErr != nil {
+			return false, fmt.Errorf("read initramfs entry %q: %w", hdr.Name, readAllErr)
+		}
+		return scanCPIOForVirtiofs(initrdData)
+	}
+
+	return false, fmt.Errorf("initramfs entry not found in kernel layer tar (tried: %s)",
+		strings.Join(initrdEntryNames, ", "))
+}
+
+// isInitrdEntry checks whether a tar header name matches one of the known
+// initramfs filenames (with or without a leading "./" or "/" prefix).
+func isInitrdEntry(name string) bool {
+	// Normalize: strip leading "./" or "/" to compare bare names.
+	clean := strings.TrimPrefix(strings.TrimPrefix(name, "./"), "/")
+	return slices.Contains(initrdEntryNames, clean)
+}
+
+// scanCPIOForVirtiofs decompresses the initramfs data (detecting gzip by magic
+// bytes) and scans the resulting cpio archive for any entry path containing
+// "virtiofs.ko".
+//
+// The cpio format is intentionally parsed with a minimal hand-rolled reader
+// rather than importing a full cpio library, keeping dependencies lean.
+func scanCPIOForVirtiofs(data []byte) (bool, error) {
+	raw, err := decompressInitramfs(data)
+	if err != nil {
+		return false, fmt.Errorf("decompress initramfs: %w", err)
+	}
+	return cpioContainsVirtiofs(raw), nil
+}
+
+// decompressInitramfs detects the compression format by magic bytes and
+// returns the decompressed payload. Supported: gzip, zstd (magic 0x28B52FFD),
+// and uncompressed (assumed cpio).
+func decompressInitramfs(data []byte) ([]byte, error) {
+	if len(data) < 4 {
+		return nil, fmt.Errorf("initramfs data too small (%d bytes)", len(data))
+	}
+
+	// Gzip: magic 0x1F 0x8B
+	if data[0] == 0x1F && data[1] == 0x8B {
+		return decompressGzip(data)
+	}
+
+	// Zstd: magic 0x28 0xB5 0x2F 0xFD
+	if data[0] == 0x28 && data[1] == 0xB5 && data[2] == 0x2F && data[3] == 0xFD {
+		// Zstd decompression requires cgo or a large pure-Go dependency.
+		// Rather than adding a dependency, return an informative error so
+		// the caller can report it as a warning.
+		return nil, fmt.Errorf("zstd-compressed initramfs detected; virtiofs check not supported for zstd")
+	}
+
+	// Assume uncompressed cpio (newc format magic "070701" or binary).
+	return data, nil
+}
+
+// decompressGzip decompresses gzip data.
+func decompressGzip(data []byte) ([]byte, error) {
+	r, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("gzip reader: %w", err)
+	}
+	defer r.Close() //nolint:errcheck
+	out, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("gzip decompress: %w", err)
+	}
+	return out, nil
+}
+
+// cpioContainsVirtiofs scans raw cpio bytes (newc format) for any entry whose
+// filename path contains "virtiofs.ko". It uses a minimal cpio newc parser.
+//
+// newc format (per man 5 cpio):
+//
+//	"070701" magic (6 bytes ASCII)
+//	13 x 8-byte hex fields (104 bytes)
+//	filename (null-terminated, padded to 4-byte boundary)
+//	file data (padded to 4-byte boundary)
+//
+// The trailer entry has name "TRAILER!!!".
+func cpioContainsVirtiofs(data []byte) bool {
+	const (
+		magicNewc = "070701"
+		magicCrc  = "070702"
+		headerLen = 110 // 6 (magic) + 13*8 (fields)
+	)
+
+	offset := 0
+	for offset+headerLen <= len(data) {
+		magic := string(data[offset : offset+6])
+		if magic != magicNewc && magic != magicCrc {
+			// Not a recognized cpio header; stop scanning.
+			return false
+		}
+
+		// Parse namesize (hex, 8 chars, offset 94 from header start).
+		namesize, ok := parseHex8(data[offset+94 : offset+102])
+		if !ok {
+			return false
+		}
+
+		// Parse filesize (hex, 8 chars, offset 54 from header start).
+		filesize, ok := parseHex8(data[offset+54 : offset+62])
+		if !ok {
+			return false
+		}
+
+		// Extract filename.
+		nameStart := offset + headerLen
+		nameEnd := nameStart + int(namesize)
+		if nameEnd > len(data) {
+			return false
+		}
+
+		// Filename includes trailing NUL; trim it for comparison.
+		name := strings.TrimRight(string(data[nameStart:nameEnd]), "\x00")
+
+		// Check for trailer.
+		if name == "TRAILER!!!" {
+			return false
+		}
+
+		// Check if this entry path contains virtiofs.ko (with or without
+		// compression extension).
+		if containsVirtiofsModule(name) {
+			return true
+		}
+
+		// Advance past header + name (padded to 4) + data (padded to 4).
+		nameTotal := align4(headerLen + int(namesize))
+		dataTotal := align4(int(filesize))
+		offset += nameTotal + dataTotal
+	}
+
+	return false
+}
+
+// containsVirtiofsModule returns true if the path contains a virtiofs kernel
+// module filename (virtiofs.ko, virtiofs.ko.xz, virtiofs.ko.zst, virtiofs.ko.gz).
+func containsVirtiofsModule(path string) bool {
+	// Match by checking if any path segment ends with a virtiofs module name.
+	suffixes := []string{
+		"virtiofs.ko",
+		"virtiofs.ko.xz",
+		"virtiofs.ko.zst",
+		"virtiofs.ko.gz",
+	}
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(path, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseHex8 parses an 8-byte ASCII hex string into a uint32.
+func parseHex8(b []byte) (uint32, bool) {
+	if len(b) != 8 {
+		return 0, false
+	}
+	var val uint32
+	for _, c := range b {
+		val <<= 4
+		switch {
+		case c >= '0' && c <= '9':
+			val |= uint32(c - '0')
+		case c >= 'a' && c <= 'f':
+			val |= uint32(c - 'a' + 10)
+		case c >= 'A' && c <= 'F':
+			val |= uint32(c - 'A' + 10)
+		default:
+			return 0, false
+		}
+	}
+	return val, true
+}
+
+// align4 rounds n up to the next multiple of 4.
+func align4(n int) int {
+	return (n + 3) &^ 3
+}

--- a/oci/initramfs_test.go
+++ b/oci/initramfs_test.go
@@ -1,0 +1,359 @@
+package oci
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildNewcCPIO constructs a minimal cpio newc archive from a list of
+// (name, content) pairs. This is used to simulate an initramfs for testing.
+func buildNewcCPIO(entries []cpioTestEntry) []byte {
+	var buf bytes.Buffer
+	ino := uint32(1)
+	for _, e := range entries {
+		writeCPIONewcEntry(&buf, ino, e.Name, e.Data)
+		ino++
+	}
+	// Write trailer.
+	writeCPIONewcEntry(&buf, 0, "TRAILER!!!", nil)
+	return buf.Bytes()
+}
+
+type cpioTestEntry struct {
+	Name string
+	Data []byte
+}
+
+// writeCPIONewcEntry writes a single cpio newc-format entry to w.
+func writeCPIONewcEntry(w *bytes.Buffer, ino uint32, name string, data []byte) {
+	nameWithNul := name + "\x00"
+	namesize := len(nameWithNul)
+	filesize := len(data)
+
+	// Header: magic + 13 hex fields of 8 chars each.
+	hdr := fmt.Sprintf("070701"+
+		"%08X"+ // ino
+		"%08X"+ // mode
+		"%08X"+ // uid
+		"%08X"+ // gid
+		"%08X"+ // nlink
+		"%08X"+ // mtime
+		"%08X"+ // filesize
+		"%08X"+ // devmajor
+		"%08X"+ // devminor
+		"%08X"+ // rdevmajor
+		"%08X"+ // rdevminor
+		"%08X"+ // namesize
+		"%08X", // check
+		ino,
+		0o100644,  // mode (regular file)
+		uint32(0), // uid
+		uint32(0), // gid
+		uint32(1), // nlink
+		uint32(0), // mtime
+		uint32(filesize),
+		uint32(0), // devmajor
+		uint32(0), // devminor
+		uint32(0), // rdevmajor
+		uint32(0), // rdevminor
+		uint32(namesize),
+		uint32(0), // check
+	)
+
+	w.WriteString(hdr)
+	w.WriteString(nameWithNul)
+
+	// Pad header + name to 4-byte boundary.
+	headerPlusName := 110 + namesize
+	if pad := align4(headerPlusName) - headerPlusName; pad > 0 {
+		w.Write(make([]byte, pad))
+	}
+
+	// Write data.
+	w.Write(data)
+
+	// Pad data to 4-byte boundary.
+	if pad := align4(filesize) - filesize; pad > 0 {
+		w.Write(make([]byte, pad))
+	}
+}
+
+func TestCheckInitramfsVirtiofs_Found(t *testing.T) {
+	t.Parallel()
+
+	// Build a cpio archive with a virtiofs.ko entry.
+	cpioData := buildNewcCPIO([]cpioTestEntry{
+		{Name: "lib/modules/6.8.0-40-generic/kernel/fs/fuse/virtiofs.ko", Data: []byte("ELF-fake")},
+		{Name: "bin/busybox", Data: []byte("busybox-binary")},
+	})
+
+	// Gzip-compress the cpio (most common initramfs format).
+	var gzBuf bytes.Buffer
+	gzw := gzip.NewWriter(&gzBuf)
+	if _, err := gzw.Write(cpioData); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+
+	// Build a kernel layer tar containing the initramfs.
+	layerTar := buildTestKernelTar(t, "initrd.img", gzBuf.Bytes())
+
+	// Write tar to a temp file.
+	tmpDir := t.TempDir()
+	layerPath := filepath.Join(tmpDir, "kernel-layer.tar")
+	if err := os.WriteFile(layerPath, layerTar, 0o644); err != nil {
+		t.Fatalf("write kernel layer tar: %v", err)
+	}
+
+	found, err := CheckInitramfsVirtiofs(layerPath)
+	if err != nil {
+		t.Fatalf("CheckInitramfsVirtiofs: %v", err)
+	}
+	if !found {
+		t.Fatal("expected virtiofs module to be found")
+	}
+}
+
+func TestCheckInitramfsVirtiofs_NotFound(t *testing.T) {
+	t.Parallel()
+
+	// Build a cpio archive without virtiofs.
+	cpioData := buildNewcCPIO([]cpioTestEntry{
+		{Name: "lib/modules/6.8.0-40-generic/kernel/fs/ext4/ext4.ko", Data: []byte("ELF-fake")},
+		{Name: "bin/busybox", Data: []byte("busybox-binary")},
+	})
+
+	var gzBuf bytes.Buffer
+	gzw := gzip.NewWriter(&gzBuf)
+	if _, err := gzw.Write(cpioData); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+
+	layerTar := buildTestKernelTar(t, "initrd.img", gzBuf.Bytes())
+	tmpDir := t.TempDir()
+	layerPath := filepath.Join(tmpDir, "kernel-layer.tar")
+	if err := os.WriteFile(layerPath, layerTar, 0o644); err != nil {
+		t.Fatalf("write kernel layer tar: %v", err)
+	}
+
+	found, err := CheckInitramfsVirtiofs(layerPath)
+	if err != nil {
+		t.Fatalf("CheckInitramfsVirtiofs: %v", err)
+	}
+	if found {
+		t.Fatal("expected virtiofs module NOT to be found")
+	}
+}
+
+func TestCheckInitramfsVirtiofs_UncompressedCPIO(t *testing.T) {
+	t.Parallel()
+
+	// Build an uncompressed cpio archive with virtiofs.ko.xz.
+	cpioData := buildNewcCPIO([]cpioTestEntry{
+		{Name: "lib/modules/6.8.0/kernel/fs/fuse/virtiofs.ko.xz", Data: []byte("XZ-compressed")},
+	})
+
+	layerTar := buildTestKernelTar(t, "initrd.img", cpioData)
+	tmpDir := t.TempDir()
+	layerPath := filepath.Join(tmpDir, "kernel-layer.tar")
+	if err := os.WriteFile(layerPath, layerTar, 0o644); err != nil {
+		t.Fatalf("write kernel layer tar: %v", err)
+	}
+
+	found, err := CheckInitramfsVirtiofs(layerPath)
+	if err != nil {
+		t.Fatalf("CheckInitramfsVirtiofs: %v", err)
+	}
+	if !found {
+		t.Fatal("expected virtiofs.ko.xz to be found in uncompressed cpio")
+	}
+}
+
+func TestCheckInitramfsVirtiofs_ZstdReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Simulate a zstd-compressed initramfs (magic bytes 0x28B52FFD + dummy data).
+	zstdMagic := []byte{0x28, 0xB5, 0x2F, 0xFD}
+	initrdData := append(zstdMagic, make([]byte, 100)...)
+
+	layerTar := buildTestKernelTar(t, "initrd.img", initrdData)
+	tmpDir := t.TempDir()
+	layerPath := filepath.Join(tmpDir, "kernel-layer.tar")
+	if err := os.WriteFile(layerPath, layerTar, 0o644); err != nil {
+		t.Fatalf("write kernel layer tar: %v", err)
+	}
+
+	found, err := CheckInitramfsVirtiofs(layerPath)
+	if err == nil {
+		t.Fatalf("expected error for zstd initramfs, got found=%v", found)
+	}
+	if !strings.Contains(err.Error(), "zstd") {
+		t.Fatalf("expected zstd-related error, got: %v", err)
+	}
+}
+
+func TestCheckInitramfsVirtiofs_NoInitrdEntry(t *testing.T) {
+	t.Parallel()
+
+	// Build a kernel layer tar with only vmlinuz (no initrd).
+	layerTar := buildTestKernelTar(t, "vmlinuz", []byte("kernel-binary"))
+	tmpDir := t.TempDir()
+	layerPath := filepath.Join(tmpDir, "kernel-layer.tar")
+	if err := os.WriteFile(layerPath, layerTar, 0o644); err != nil {
+		t.Fatalf("write kernel layer tar: %v", err)
+	}
+
+	found, err := CheckInitramfsVirtiofs(layerPath)
+	if err == nil {
+		t.Fatalf("expected error for missing initrd, got found=%v", found)
+	}
+	if !strings.Contains(err.Error(), "initramfs entry not found") {
+		t.Fatalf("expected 'initramfs entry not found' error, got: %v", err)
+	}
+	if found {
+		t.Fatal("found should be false when initrd is missing")
+	}
+}
+
+func TestContainsVirtiofsModule(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "bare-ko", path: "lib/modules/6.8.0/kernel/fs/fuse/virtiofs.ko", want: true},
+		{name: "xz-compressed", path: "lib/modules/6.8.0/kernel/fs/fuse/virtiofs.ko.xz", want: true},
+		{name: "zst-compressed", path: "lib/modules/6.8.0/kernel/fs/fuse/virtiofs.ko.zst", want: true},
+		{name: "gz-compressed", path: "lib/modules/6.8.0/kernel/fs/fuse/virtiofs.ko.gz", want: true},
+		{name: "different-module", path: "lib/modules/6.8.0/kernel/fs/ext4/ext4.ko", want: false},
+		{name: "partial-match", path: "lib/modules/6.8.0/kernel/fs/fuse/virtiofs.ko.bak", want: false},
+		{name: "empty", path: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := containsVirtiofsModule(tt.path); got != tt.want {
+				t.Fatalf("containsVirtiofsModule(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsInitrdEntry(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "bare", path: "initrd.img", want: true},
+		{name: "dot-slash", path: "./initrd.img", want: true},
+		{name: "slash", path: "/initrd.img", want: true},
+		{name: "initramfs.img", path: "initramfs.img", want: true},
+		{name: "initrd-bare", path: "initrd", want: true},
+		{name: "initramfs-bare", path: "initramfs", want: true},
+		{name: "vmlinuz", path: "vmlinuz", want: false},
+		{name: "subdir-initrd", path: "boot/initrd.img", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isInitrdEntry(tt.path); got != tt.want {
+				t.Fatalf("isInitrdEntry(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseHex8(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want uint32
+		ok   bool
+	}{
+		{name: "zero", in: "00000000", want: 0, ok: true},
+		{name: "one", in: "00000001", want: 1, ok: true},
+		{name: "max", in: "FFFFFFFF", want: 0xFFFFFFFF, ok: true},
+		{name: "mixed-case", in: "0000000a", want: 10, ok: true},
+		{name: "realistic-filesize", in: "0000A000", want: 0xA000, ok: true},
+		{name: "too-short", in: "0000", want: 0, ok: false},
+		{name: "invalid-char", in: "0000000G", want: 0, ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := parseHex8([]byte(tt.in))
+			if ok != tt.ok {
+				t.Fatalf("parseHex8(%q) ok=%v, want %v", tt.in, ok, tt.ok)
+			}
+			if ok && got != tt.want {
+				t.Fatalf("parseHex8(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAlign4(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   int
+		want int
+	}{
+		{0, 0},
+		{1, 4},
+		{2, 4},
+		{3, 4},
+		{4, 4},
+		{5, 8},
+		{110, 112},
+	}
+
+	for _, tt := range tests {
+		if got := align4(tt.in); got != tt.want {
+			t.Fatalf("align4(%d) = %d, want %d", tt.in, got, tt.want)
+		}
+	}
+}
+
+// buildTestKernelTar creates a tar archive with a single entry.
+func buildTestKernelTar(t *testing.T, name string, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+
+	if err := tw.WriteHeader(&tar.Header{
+		Name: name,
+		Mode: 0o644,
+		Size: int64(len(data)),
+	}); err != nil {
+		t.Fatalf("write tar header for %s: %v", name, err)
+	}
+	if _, err := tw.Write(data); err != nil {
+		t.Fatalf("write tar data for %s: %v", name, err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar writer: %v", err)
+	}
+	return buf.Bytes()
+}


### PR DESCRIPTION
## Summary

- Add virtiofs kernel module detection to `cocoon image verify` for OCI VM images
- When verifying an OCI VM image, the kernel layer tar is inspected for an initramfs entry, which is then scanned (via cpio newc parsing) for `virtiofs.ko` (including `.xz`, `.zst`, `.gz` variants)
- Results are reported as `VirtiofsChecked`/`VirtiofsFound` fields on `BootCheckResult` and surfaced as PASS/WARN messages in the verify output
- Implements the Section 6.5 requirement from docs/04.1 (initramfs virtiofs support check)

## Changes

| File | Description |
|------|-------------|
| `oci/initramfs.go` | New: `CheckInitramfsVirtiofs()` — opens kernel layer tar, finds initrd entry, decompresses (gzip/uncompressed), scans cpio newc for virtiofs.ko |
| `oci/initramfs_test.go` | Tests: found/not-found/uncompressed/zstd-error/missing-initrd cases plus unit tests for cpio helpers |
| `cmd/cocoon/images.go` | Wire `checkInitramfsVirtiofs()` into `verifyOCILayoutBootability()` |
| `cmd/cocoon/images_test.go` | Integration tests: no-kernel-layer, nil-info, bad-blob-path edge cases |
| `image/types.go` | Add `VirtiofsFound`/`VirtiofsChecked` fields to `BootCheckResult` |

## Design decisions

- **Minimal cpio parser**: Hand-rolled newc format parser instead of importing a full cpio library, keeping dependencies lean
- **Gzip decompression only**: Gzip is supported natively; zstd returns an informative error (avoiding a cgo or large pure-Go dependency)
- **Non-blocking**: Virtiofs absence is a WARN, not an error — the image is still considered bootable since virtiofs may be compiled into the kernel or loaded via other means

## Test plan

- [x] `make fmt` — passes
- [x] `make lint` — 0 issues (both linux and darwin)
- [x] `make test` — all tests pass with race detector
- [ ] Manual: `cocoon image verify <oci-tag>` on an image with virtiofs in initramfs → should show "virtiofs module found in initramfs"
- [ ] Manual: `cocoon image verify <oci-tag>` on an image without virtiofs → should show warning about missing virtiofs

🤖 Generated with [Claude Code](https://claude.com/claude-code)