### PR TITLE
feat: add virtiofs module check to image verify for OCI VM images

### DIFF
--- a/cmd/cocoon/images.go
+++ b/cmd/cocoon/images.go
@@ -926,7 +926,12 @@ func verifyOCILayoutBootability(layoutPath string) (*image.BootCheckResult, erro
 	if err != nil {
 		return nil, fmt.Errorf("inspect OCI layout: %w", err)
 	}
-	return evaluateOCILayoutBootability(info), nil
+	result := evaluateOCILayoutBootability(info)
+
+	// Check initramfs for virtiofs module support.
+	checkInitramfsVirtiofs(result, info, layoutPath)
+
+	return result, nil
 }
 
 func evaluateOCILayoutBootability(info *oci.LayoutInfo) *image.BootCheckResult {
@@ -986,6 +991,47 @@ func validateOCIVMConfig(result *image.BootCheckResult, cfg *oci.VMImageConfig) 
 	}
 	if strings.TrimSpace(cfg.KernelCmdline) == "" {
 		result.Warnings = append(result.Warnings, "config.kernel_cmdline is empty")
+	}
+}
+
+// checkInitramfsVirtiofs locates the kernel layer blob and scans its initramfs
+// for the virtiofs kernel module. Results are recorded in the BootCheckResult
+// as a non-blocking warning.
+func checkInitramfsVirtiofs(result *image.BootCheckResult, info *oci.LayoutInfo, layoutPath string) {
+	if info == nil {
+		return
+	}
+
+	// Find the kernel layer digest.
+	var kernelDigest string
+	for _, layer := range info.Layers {
+		if layer.MediaType == oci.MediaTypeKernelLayer {
+			kernelDigest = layer.Digest
+			break
+		}
+	}
+	if kernelDigest == "" {
+		return // no kernel layer — already reported as an error elsewhere
+	}
+
+	blobPath, err := oci.LayoutBlobPath(layoutPath, kernelDigest)
+	if err != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("virtiofs check: resolve kernel blob path: %v", err))
+		return
+	}
+
+	found, err := oci.CheckInitramfsVirtiofs(blobPath)
+	if err != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("virtiofs check: %v", err))
+		return
+	}
+
+	result.VirtiofsChecked = true
+	result.VirtiofsFound = found
+
+	if !found {
+		result.Warnings = append(result.Warnings,
+			"virtiofs module not found in initramfs \u2014 OCI VM direct boot may fail")
 	}
 }
 

--- a/image/types.go
+++ b/image/types.go
@@ -120,6 +120,12 @@ type BootCheckResult struct {
 	BootloaderFound bool `json:"bootloader_found"`
 	// BootloaderChecked indicates the bootloader check completed.
 	BootloaderChecked bool `json:"bootloader_checked"`
+
+	// VirtiofsFound indicates whether a virtiofs kernel module was detected
+	// in the initramfs of the kernel layer.
+	VirtiofsFound bool `json:"virtiofs_found"`
+	// VirtiofsChecked indicates the virtiofs module check completed.
+	VirtiofsChecked bool `json:"virtiofs_checked"`
 }
 
 // CachedImage describes a base image stored in the image cache.

--- a/oci/initramfs.go
+++ b/oci/initramfs.go
@@ -1,0 +1,216 @@
+package oci
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// initramfs entry names to search for inside the kernel layer tar.
+var initramfsNames = []string{
+	"initrd.img",
+	"initrd",
+	"initramfs.img",
+	"initramfs",
+}
+
+// CheckInitramfsVirtiofs opens a kernel layer tar blob, locates the initramfs
+// entry, decompresses it (gzip or uncompressed cpio), and scans cpio newc
+// entry names for a virtiofs kernel module (virtiofs.ko, .ko.xz, .ko.zst,
+// .ko.gz).
+//
+// Returns (true, nil) if virtiofs module found, (false, nil) if not found or
+// no initramfs entry exists, and (false, err) on read/parse errors.
+func CheckInitramfsVirtiofs(kernelLayerBlobPath string) (bool, error) {
+	initramfsData, err := extractInitramfsFromTar(kernelLayerBlobPath)
+	if err != nil {
+		return false, err
+	}
+	if initramfsData == nil {
+		// No initramfs entry in the kernel layer tar — not an error,
+		// but we cannot check for virtiofs.
+		return false, nil
+	}
+
+	cpioData, err := decompressInitramfs(initramfsData)
+	if err != nil {
+		return false, fmt.Errorf("decompress initramfs: %w", err)
+	}
+
+	return scanCpioForVirtiofs(cpioData)
+}
+
+// extractInitramfsFromTar opens the kernel layer tar and returns the raw bytes
+// of the first initramfs entry found. Returns (nil, nil) if no initramfs
+// entry is present.
+func extractInitramfsFromTar(tarPath string) ([]byte, error) {
+	f, err := os.Open(tarPath) //nolint:gosec // G304: tarPath is from local OCI layout blob store
+	if err != nil {
+		return nil, fmt.Errorf("open kernel layer tar: %w", err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	nameSet := make(map[string]struct{}, len(initramfsNames))
+	for _, n := range initramfsNames {
+		nameSet[n] = struct{}{}
+	}
+
+	tr := tar.NewReader(f)
+	for {
+		hdr, rerr := tr.Next()
+		if rerr == io.EOF {
+			break
+		}
+		if rerr != nil {
+			return nil, fmt.Errorf("read kernel layer tar: %w", rerr)
+		}
+
+		// Normalize: strip leading "./" or "/".
+		name := strings.TrimPrefix(hdr.Name, "./")
+		name = strings.TrimPrefix(name, "/")
+
+		if _, ok := nameSet[name]; ok {
+			data, readErr := io.ReadAll(tr)
+			if readErr != nil {
+				return nil, fmt.Errorf("read initramfs entry %q: %w", hdr.Name, readErr)
+			}
+			return data, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// decompressInitramfs detects the compression format and returns raw cpio data.
+// Supported: gzip (\x1f\x8b), uncompressed cpio (070701 magic).
+// Returns an error for zstd (\x28\xb5\x2f\xfd) since stdlib doesn't support it.
+func decompressInitramfs(data []byte) ([]byte, error) {
+	if len(data) < 4 {
+		return nil, fmt.Errorf("initramfs data too short (%d bytes)", len(data))
+	}
+
+	// Gzip magic: 0x1f 0x8b
+	if data[0] == 0x1f && data[1] == 0x8b {
+		gz, err := gzip.NewReader(bytes.NewReader(data))
+		if err != nil {
+			return nil, fmt.Errorf("open gzip reader: %w", err)
+		}
+		defer gz.Close() //nolint:errcheck
+		decompressed, err := io.ReadAll(gz)
+		if err != nil {
+			return nil, fmt.Errorf("decompress gzip: %w", err)
+		}
+		return decompressed, nil
+	}
+
+	// Zstd magic: 0x28 0xb5 0x2f 0xfd
+	if data[0] == 0x28 && data[1] == 0xb5 && data[2] == 0x2f && data[3] == 0xfd {
+		return nil, fmt.Errorf("zstd-compressed initramfs is not supported: stdlib does not include a zstd decoder; re-build the initramfs with gzip or install a zstd-capable kernel")
+	}
+
+	// Uncompressed cpio newc magic: "070701" (ASCII).
+	if len(data) >= 6 && string(data[:6]) == "070701" {
+		return data, nil
+	}
+
+	return nil, fmt.Errorf("unrecognized initramfs format (magic: %s)", hex.EncodeToString(data[:4]))
+}
+
+// scanCpioForVirtiofs parses a cpio newc archive and returns true if any entry
+// name contains "virtiofs.ko" (covers .ko, .ko.xz, .ko.zst, .ko.gz).
+//
+// The cpio newc format (see "man 5 cpio") uses fixed-size ASCII hex headers:
+//
+//	Offset  Length  Field
+//	0       6       magic "070701"
+//	6       8       inode
+//	14      8       mode
+//	22      8       uid
+//	30      8       gid
+//	38      8       nlink
+//	46      8       mtime
+//	54      8       filesize
+//	62      8       devmajor
+//	70      8       devminor
+//	78      8       rdevmajor
+//	86      8       rdevminor
+//	94      8       namesize
+//	102     8       checksum
+//	110     (namesize bytes, padded to 4-byte boundary)
+//	        (filesize bytes, padded to 4-byte boundary)
+func scanCpioForVirtiofs(data []byte) (bool, error) {
+	const headerLen = 110 // fixed cpio newc header size
+
+	offset := 0
+	for offset+headerLen <= len(data) {
+		// Verify magic.
+		magic := string(data[offset : offset+6])
+		if magic != "070701" {
+			// End of archive or corrupted — stop scanning.
+			break
+		}
+
+		// Parse namesize (8 hex chars at offset 94).
+		namesize, err := parseHex8(data[offset+94 : offset+102])
+		if err != nil {
+			return false, fmt.Errorf("parse cpio namesize at offset %d: %w", offset, err)
+		}
+
+		// Parse filesize (8 hex chars at offset 54).
+		filesize, err := parseHex8(data[offset+54 : offset+62])
+		if err != nil {
+			return false, fmt.Errorf("parse cpio filesize at offset %d: %w", offset, err)
+		}
+
+		// Read entry name.
+		nameStart := offset + headerLen
+		nameEnd := nameStart + int(namesize)
+		if nameEnd > len(data) {
+			break
+		}
+
+		// Name includes trailing NUL byte — strip it.
+		name := string(data[nameStart:nameEnd])
+		name = strings.TrimRight(name, "\x00")
+
+		// TRAILER!!! marks end of archive.
+		if name == "TRAILER!!!" {
+			break
+		}
+
+		// Check for virtiofs module.
+		if strings.Contains(name, "virtiofs.ko") {
+			return true, nil
+		}
+
+		// Advance past header + name (padded to 4 bytes) + file data (padded to 4 bytes).
+		nameTotal := alignUp(headerLen+int(namesize), 4)
+		dataTotal := alignUp(int(filesize), 4)
+		offset += nameTotal + dataTotal
+	}
+
+	return false, nil
+}
+
+// parseHex8 parses 8 bytes of ASCII hexadecimal into a uint32.
+func parseHex8(b []byte) (uint32, error) {
+	if len(b) != 8 {
+		return 0, fmt.Errorf("expected 8 hex bytes, got %d", len(b))
+	}
+	decoded, err := hex.DecodeString(string(b))
+	if err != nil {
+		return 0, fmt.Errorf("decode hex %q: %w", string(b), err)
+	}
+	return binary.BigEndian.Uint32(decoded), nil
+}
+
+// alignUp rounds n up to the next multiple of align.
+func alignUp(n, align int) int {
+	return (n + align - 1) &^ (align - 1)
+}

--- a/oci/initramfs_test.go
+++ b/oci/initramfs_test.go
@@ -1,0 +1,246 @@
+package oci
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// buildCpioNewc constructs a minimal cpio newc archive containing the given
+// entry names (all with zero-length file data). The archive is terminated with
+// a TRAILER!!! entry.
+func buildCpioNewc(names []string) []byte {
+	var buf bytes.Buffer
+	for _, name := range names {
+		writeCpioEntry(&buf, name, nil)
+	}
+	writeCpioEntry(&buf, "TRAILER!!!", nil)
+	return buf.Bytes()
+}
+
+// writeCpioEntry writes one cpio newc entry (header + name + data) to w.
+func writeCpioEntry(buf *bytes.Buffer, name string, data []byte) {
+	nameBytes := append([]byte(name), 0) // include trailing NUL
+	namesize := len(nameBytes)
+	filesize := len(data)
+
+	// Fixed 110-byte header: all fields as 8-char hex, except magic (6 chars).
+	hdr := fmt.Sprintf(
+		"070701"+
+			"%08x"+ // inode
+			"%08x"+ // mode
+			"%08x"+ // uid
+			"%08x"+ // gid
+			"%08x"+ // nlink
+			"%08x"+ // mtime
+			"%08x"+ // filesize
+			"%08x"+ // devmajor
+			"%08x"+ // devminor
+			"%08x"+ // rdevmajor
+			"%08x"+ // rdevminor
+			"%08x"+ // namesize
+			"%08x", // checksum
+		0,        // inode
+		0o100644, // mode
+		0,        // uid
+		0,        // gid
+		1,        // nlink
+		0,        // mtime
+		filesize, // filesize
+		0,        // devmajor
+		0,        // devminor
+		0,        // rdevmajor
+		0,        // rdevminor
+		namesize, // namesize
+		0,        // checksum
+	)
+
+	buf.WriteString(hdr)
+	buf.Write(nameBytes)
+
+	// Pad header + name to 4-byte boundary.
+	headerAndName := 110 + namesize
+	if pad := alignUp(headerAndName, 4) - headerAndName; pad > 0 {
+		buf.Write(make([]byte, pad))
+	}
+
+	// Write file data.
+	if len(data) > 0 {
+		buf.Write(data)
+	}
+
+	// Pad file data to 4-byte boundary.
+	if pad := alignUp(filesize, 4) - filesize; pad > 0 {
+		buf.Write(make([]byte, pad))
+	}
+}
+
+// gzipData compresses data using gzip.
+func gzipData(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write(data); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// buildKernelTarWithInitramfs creates a kernel layer tar containing an
+// initramfs entry with the given name and raw data.
+func buildKernelTarWithInitramfs(t *testing.T, dir, initramfsName string, initramfsData []byte) string {
+	t.Helper()
+	tarPath := filepath.Join(dir, "kernel-layer.tar")
+	f, err := os.Create(tarPath)
+	if err != nil {
+		t.Fatalf("create tar: %v", err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	tw := tar.NewWriter(f)
+
+	// Write a vmlinuz entry (dummy).
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "vmlinuz",
+		Size: 4,
+		Mode: 0o644,
+	}); err != nil {
+		t.Fatalf("write vmlinuz header: %v", err)
+	}
+	if _, err := tw.Write([]byte("kern")); err != nil {
+		t.Fatalf("write vmlinuz body: %v", err)
+	}
+
+	// Write the initramfs entry.
+	if initramfsName != "" {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: initramfsName,
+			Size: int64(len(initramfsData)),
+			Mode: 0o644,
+		}); err != nil {
+			t.Fatalf("write initramfs header: %v", err)
+		}
+		if _, err := tw.Write(initramfsData); err != nil {
+			t.Fatalf("write initramfs body: %v", err)
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	return tarPath
+}
+
+func TestCheckInitramfsVirtiofs_GzipWithVirtiofs(t *testing.T) {
+	t.Parallel()
+
+	cpioData := buildCpioNewc([]string{
+		"kernel/fs/fuse/fuse.ko",
+		"kernel/fs/fuse/virtiofs.ko",
+		"kernel/drivers/virtio/virtio.ko",
+	})
+	compressed := gzipData(t, cpioData)
+
+	dir := t.TempDir()
+	tarPath := buildKernelTarWithInitramfs(t, dir, "initrd.img", compressed)
+
+	found, err := CheckInitramfsVirtiofs(tarPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Errorf("expected virtiofs found=true, got false")
+	}
+}
+
+func TestCheckInitramfsVirtiofs_GzipWithoutVirtiofs(t *testing.T) {
+	t.Parallel()
+
+	cpioData := buildCpioNewc([]string{
+		"kernel/fs/fuse/fuse.ko",
+		"kernel/drivers/virtio/virtio.ko",
+		"kernel/net/core/net.ko",
+	})
+	compressed := gzipData(t, cpioData)
+
+	dir := t.TempDir()
+	tarPath := buildKernelTarWithInitramfs(t, dir, "initrd.img", compressed)
+
+	found, err := CheckInitramfsVirtiofs(tarPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found {
+		t.Errorf("expected virtiofs found=false, got true")
+	}
+}
+
+func TestCheckInitramfsVirtiofs_UncompressedWithVirtiofsXZ(t *testing.T) {
+	t.Parallel()
+
+	cpioData := buildCpioNewc([]string{
+		"kernel/fs/fuse/fuse.ko",
+		"kernel/fs/fuse/virtiofs.ko.xz",
+	})
+
+	dir := t.TempDir()
+	tarPath := buildKernelTarWithInitramfs(t, dir, "initramfs.img", cpioData)
+
+	found, err := CheckInitramfsVirtiofs(tarPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Errorf("expected virtiofs found=true for .ko.xz, got false")
+	}
+}
+
+func TestCheckInitramfsVirtiofs_ZstdReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Zstd magic: 0x28 0xb5 0x2f 0xfd followed by dummy bytes.
+	zstdMagic, _ := hex.DecodeString("28b52ffd") //nolint:errcheck
+	zstdData := append(zstdMagic, make([]byte, 100)...)
+
+	dir := t.TempDir()
+	tarPath := buildKernelTarWithInitramfs(t, dir, "initrd.img", zstdData)
+
+	found, err := CheckInitramfsVirtiofs(tarPath)
+	if err == nil {
+		t.Fatalf("expected error for zstd initramfs, got nil (found=%v)", found)
+	}
+	if found {
+		t.Errorf("expected found=false on error, got true")
+	}
+	if got := err.Error(); !contains(got, "zstd") {
+		t.Errorf("error should mention zstd, got: %s", got)
+	}
+}
+
+func TestCheckInitramfsVirtiofs_NoInitrdEntry(t *testing.T) {
+	t.Parallel()
+
+	// Build a kernel tar with only vmlinuz, no initramfs entry.
+	dir := t.TempDir()
+	tarPath := buildKernelTarWithInitramfs(t, dir, "", nil)
+
+	found, err := CheckInitramfsVirtiofs(tarPath)
+	if err != nil {
+		t.Fatalf("expected no error for missing initrd, got: %v", err)
+	}
+	if found {
+		t.Errorf("expected found=false when no initrd entry, got true")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && bytes.Contains([]byte(s), []byte(substr))
+}


### PR DESCRIPTION
## Summary

- Add `oci.CheckInitramfsVirtiofs()` to scan kernel layer initramfs for `virtiofs.ko` module presence
- Supports gzip-compressed and uncompressed cpio newc archives; returns descriptive error for zstd
- Wire the check into `verifyOCILayoutBootability` so `cocoon image verify` reports virtiofs status
- Add `VirtiofsFound` / `VirtiofsChecked` fields to `BootCheckResult`
- Missing virtiofs module is reported as a warning (non-blocking), not an error

## Test plan

- [x] `TestCheckInitramfsVirtiofs_GzipWithVirtiofs` -- gzip cpio with virtiofs.ko returns found=true
- [x] `TestCheckInitramfsVirtiofs_GzipWithoutVirtiofs` -- gzip cpio without virtiofs returns found=false
- [x] `TestCheckInitramfsVirtiofs_UncompressedWithVirtiofsXZ` -- uncompressed cpio with virtiofs.ko.xz returns found=true
- [x] `TestCheckInitramfsVirtiofs_ZstdReturnsError` -- zstd magic bytes returns descriptive error
- [x] `TestCheckInitramfsVirtiofs_NoInitrdEntry` -- kernel tar without initrd returns found=false, no error
- [x] `make fmt` -- no formatting changes needed
- [x] `make lint` -- 0 issues (linux + darwin)
- [x] `make test` -- all packages pass with race detector

Closes docs/04.1 Section 6.5 requirement for initramfs virtiofs verification.

Generated with [Claude Code](https://claude.com/claude-code)
