### PR TITLE
fix: gate OCI initramfs before promote and enforce serial console output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,126 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Test Commands
+
+```bash
+make build          # Build cocoon binary (CGO_ENABLED=0)
+make lint           # Lint for BOTH linux and darwin (golangci-lint v2, auto-downloaded)
+make test           # Tests with -race -count=1 -cover (includes go vet)
+make fmt            # Format with gofumpt + goimports
+make ci             # Full CI: fmt-check + vet + lint + test + build
+
+# Run a single test
+go test -run TestFunctionName ./path/to/package/
+
+# Run tests for a single package
+go test -race -count=1 ./oci/
+```
+
+**Critical**: Always run `make lint` (not `golangci-lint` directly). The Makefile runs lint for both `GOOS=linux` and `GOOS=darwin` — the project has platform-specific files that must pass on both.
+
+## Project Overview
+
+Cocoon is a zero-daemon VM manager built on Cloud Hypervisor. One CH process per VM, Docker-like CLI (`cocoon run/create/start/stop/delete`), two boot modes: UEFI (cloud images) and direct kernel boot (OCI VM images with virtiofs rootfs).
+
+## Architecture
+
+### Package Dependency Flow
+
+```
+cmd/cocoon/        CLI commands + app wiring (app.go composes all managers)
+  ├── vm/engine/   VM lifecycle (Manager interface in vm/vm.go)
+  │     ├── hypervisor/cloudhypervisor/   CH process + REST API (Client interface)
+  │     ├── storage/local/                COW overlays + reference counting + GC
+  │     └── image/pipeline/               Cloud image pull + convert
+  ├── oci/         OCI VM image build/push/pull/store (Builder interface in image/image.go)
+  ├── config/      CocoonConfig (JSON config + derived path helpers)
+  ├── lock/flock/  File-based flock(2) locks (Locker interface)
+  └── types/       Shared types (VMConfig, VMMetadataFile, etc.)
+```
+
+### Key Interfaces (all have mock implementations in `*/mocks/`)
+
+| Interface | Package | Implementation |
+|-----------|---------|----------------|
+| `hypervisor.Client` | `hypervisor/` | `cloudhypervisor/client.go` |
+| `vm.Manager` | `vm/` | `vm/engine/manager.go` |
+| `image.Manager` | `image/` | `image/pipeline/manager.go` |
+| `image.Builder` | `image/` | `oci/builder.go` |
+| `storage.ReferenceCounter` | `storage/` | `storage/local/refcount.go` |
+| `storage.COWManager` | `storage/` | `storage/local/cow.go` |
+| `storage.GarbageCollector` | `storage/` | `storage/local/gc.go` |
+| `lock.Locker` | `lock/` | `lock/flock/flock.go` |
+
+### Platform-Specific Files
+
+The project targets Linux+KVM for VM execution but supports macOS for build/lint/test. Platform-specific code uses `_linux.go` / `_darwin.go` suffixes (no build tags):
+
+- `oci/build_linux.go` / `build_darwin.go` (OCI build — darwin is stub)
+- `oci/delta_linux.go` (layer diffing — linux only)
+- `image/pipeline/convert_linux.go` / `convert_darwin.go`
+- `image/pipeline/oci_linux.go` / `oci_darwin.go`
+- `image/pipeline/verify_linux.go` / `verify_darwin.go`
+- `vm/engine/overlay_runtime_linux.go` / `overlay_runtime_other.go`
+- `utils/process_linux.go` / `process_darwin.go`
+- `cmd/cocoon/console_linux.go` / `console_darwin.go`
+
+### Two Boot Paths
+
+1. **UEFI boot** (cloud images): firmware CLOUDHV.fd → qcow2 base + COW overlay → serial log on ttyS0
+2. **Direct kernel boot** (OCI VM images): kernel + initramfs + virtiofs rootfs → virtiofsd daemon → overlay mount → serial log on ttyS0 + console on hvc0
+
+Boot detection (`vm/engine/boot_detect.go`) polls the serial log file for success/failure regex patterns.
+
+### Storage Model
+
+- **Base images**: content-addressed by SHA-256 (`{checksum_16}_{arch}.qcow2`), immutable, shared
+- **Overlays**: per-VM qcow2 COW backed by base image
+- **OCI store**: shared blob store + per-tag OCI layouts with hardlinks
+- **Reference counting**: tracks VM→base image references, enables safe GC
+
+### Lock Hierarchy (strict ordering, flock-based, NOT reentrant)
+
+```
+L1: gc.lock           (GarbageCollector)
+L2: references.lock   (ReferenceCounter) / name-index.lock
+L3: {baseKey}.lock    (Image conversion)
+L4: {vmID}-meta.lock  (VM metadata)
+```
+
+### Persistence Pattern
+
+All mutable state uses atomic writes: write to temp file → fsync → rename. JSON files protected by flock. Config (`config.json`) is immutable after VM creation; metadata (`metadata.json`) is mutable with atomic updates.
+
+## Code Conventions
+
+### From AGENTS.md (authoritative)
+
+- **Context**: flows through parameters, never created inside business logic. Tests use `t.Context()`, not `context.Background()`.
+- **Error scope**: prefer `if err := fn(); err != nil` over separate declaration when the error is the only needed return value.
+- **Pre-commit**: `make lint && make test` before every commit, no exceptions.
+- **Git workflow**: rebase merge for PRs (`gh pr merge --rebase`).
+- **Issues**: must have Summary, Scope, Out of Scope, Acceptance Criteria (checkboxes), Checklist in the description body — this is the single source of truth.
+
+### Linter Config
+
+golangci-lint v2 (`.golangci.yml`): `gocyclo` max 30, `nestif` max 5, `nakedret` max 30 lines, `goconst` min 3 occurrences. Mocks and test files have relaxed rules. Formatter: `gofumpt` + `goimports` with local prefix `github.com/CMGS/cocoon`.
+
+### Dependency Injection
+
+Major components use function-type fields for testability (e.g., `virtiofsdRuntimeManager` has `launchFn`, `waitReadyFn`, `stopFn` fields). Constructors set production defaults; tests override with fakes.
+
+### Error Classification
+
+`types.NewPermanentError()` marks non-retryable errors (bad format, missing file). Transient errors (network, locked files) are retryable. See `oci/push.go` and `oci/pull.go` for `classifyRemoteError` patterns.
+
+## Key File Locations
+
+- **App wiring**: `cmd/cocoon/app.go` — creates all managers, the composition root
+- **VM engine** (largest file): `vm/engine/manager.go` — VM lifecycle, state machine, boot flow
+- **CH VM config builder**: `vm/engine/manager.go:buildCHVMConfig` — translates VMConfig → CHVMConfig
+- **Image resolver**: `vm/engine/image_resolver.go` — classifies image refs (local tag, cache, registry)
+- **OCI runtime**: `vm/engine/oci_runtime_prepare.go` — materializes kernel/rootfs/initrd for direct boot
+- **Config paths**: `config/config.go` — all derived path helpers (VMDir, BaseImagePath, OCILayoutDir, etc.)
+- **OCI media types**: `oci/types.go` — Cocoon VM artifact types and media types

--- a/docs/04.1-oci-vm-images.md
+++ b/docs/04.1-oci-vm-images.md
@@ -553,6 +553,8 @@ cache/oci/runtime/{runtimeKey}/
 
 The final promotion from work directory to the runtime cache entry uses a **promote-with-rotate** pattern (`promoteOCIRuntimeCacheDir`) for crash safety: the work directory is first renamed to `{runtimeKey}.new`, then the existing entry (if any) is rotated to `{runtimeKey}.old`, and finally `.new` is renamed to the final path. If the activation rename fails, the `.old` entry is rolled back. This ensures the runtime cache is never left in a half-written state -- at any point during the sequence, either the old or the new entry is fully intact.
 
+Before promotion, Cocoon validates the extracted `initrd.img` for virtiofs module support. If validation fails, promotion is aborted and the temporary work directory is removed, so no invalid runtime cache entry is published.
+
 ### 5.3 Layer Extraction
 
 Runtime materialization extracts all layers sequentially into a single `rootfs/` directory with OCI whiteouts applied inline via `applyOCIWhiteout()`. OverlayFS uses a single lowerdir:
@@ -586,7 +588,7 @@ For OCI VM images, Cocoon uses **direct kernel boot** via Cloud Hypervisor's `pa
   "payload": {
     "kernel": "/var/lib/cocoon/cache/oci/runtime/{runtimeKey}/kernel/vmlinuz",
     "initramfs": "/var/lib/cocoon/cache/oci/runtime/{runtimeKey}/kernel/initrd.img",
-    "cmdline": "root=/dev/root rootfstype=virtiofs rw console=ttyS0,115200n8 console=hvc0"
+    "cmdline": "console=ttyS0 console=hvc0 root=/dev/root rootfstype=virtiofs rw"
   },
   "fs": [
     {
@@ -599,7 +601,7 @@ For OCI VM images, Cocoon uses **direct kernel boot** via Cloud Hypervisor's `pa
 }
 ```
 
-The `cmdline` value is read from the OCI config blob's `kernel_cmdline` field. The `runtimeKey` is derived from the manifest digest (sha256 hex without prefix). The `kernel` and `initramfs` paths point to the extracted files in `cache/oci/runtime/{runtimeKey}/kernel/`. The `fs[]` entry configures virtiofs to serve the OverlayFS-merged root filesystem to the guest.
+The `cmdline` source is the OCI config blob's `kernel_cmdline` field, then Cocoon normalizes it for OCI virtiofs runtime by enforcing `console=ttyS0 console=hvc0 root=/dev/root rootfstype=virtiofs rw` (with `hvc0` last as primary console and `ttyS0` for serial-log boot detection). The `runtimeKey` is derived from the manifest digest (sha256 hex without prefix). The `kernel` and `initramfs` paths point to the extracted files in `cache/oci/runtime/{runtimeKey}/kernel/`. The `fs[]` entry configures virtiofs to serve the OverlayFS-merged root filesystem to the guest.
 
 ### 6.2 virtiofsd Lifecycle
 
@@ -641,7 +643,7 @@ No changes to the boot detection logic are required. The detection mechanism is 
 
 ### 6.5 Initramfs Requirements for virtiofs Root
 
-> **Implementation note**: OCI runtime normalizes the kernel cmdline to `root=/dev/root rootfstype=virtiofs rw` (plus console entries). This means guest initramfs must support virtiofs-root boot.
+> **Implementation note**: OCI runtime normalizes the kernel cmdline to `console=ttyS0 console=hvc0 root=/dev/root rootfstype=virtiofs rw`. This means guest initramfs must support virtiofs-root boot.
 
 **The Problem**: Direct kernel boot uses `root=/dev/root rootfstype=virtiofs` in kernel cmdline, which requires the guest initramfs to understand virtiofs root mounting. Stock cloud-image initramfs images (built by dracut or initramfs-tools) typically handle only block device roots (`/dev/sdX`, `PARTUUID=`, `UUID=`). They may not include the `virtiofs` kernel module or the early-userspace mount logic needed to mount a virtiofs filesystem as `/sysroot` before pivot_root.
 

--- a/vm/engine/manager.go
+++ b/vm/engine/manager.go
@@ -403,9 +403,6 @@ func (m *manager) createOCIVM(
 	if err != nil {
 		return nil, err
 	}
-	if checkErr := validateOCIRuntimeInitramfsVirtiofs(runtimeSpec.InitramfsPath); checkErr != nil {
-		return nil, fmt.Errorf("OCI runtime initramfs check failed for %q: %w", localTag, checkErr)
-	}
 
 	name := opts.Name
 	if name == "" {
@@ -511,25 +508,6 @@ func (m *manager) createOCIVM(
 
 	createSucceeded = true
 	return vmCfg, nil
-}
-
-func validateOCIRuntimeInitramfsVirtiofs(initramfsPath string) error {
-	path := strings.TrimSpace(initramfsPath)
-	if path == "" {
-		return fmt.Errorf("initramfs path is empty")
-	}
-
-	found, err := oci.CheckInitramfsVirtiofsFromInitrdPath(path)
-	if err != nil {
-		return fmt.Errorf("virtiofs module detection failed for %s: %w", path, err)
-	}
-	if !found {
-		return fmt.Errorf(
-			"virtiofs module not found in initramfs %s; rebuild image/initramfs with virtiofs support before create/run",
-			path,
-		)
-	}
-	return nil
 }
 
 func (m *manager) resolveOCIRuntimeLocalTag(ctx context.Context, resolvedImage *resolvedRuntimeImage) (string, error) {

--- a/vm/engine/manager_test.go
+++ b/vm/engine/manager_test.go
@@ -1820,8 +1820,8 @@ func TestBuildCHVMConfig_DirectKernelBootWithVirtioFS(t *testing.T) {
 	if chCfg.Fs[0].Socket != "/var/lib/cocoon/vms/vm-test/virtiofsd.sock" {
 		t.Fatalf("fs[0].socket = %q, want /var/lib/cocoon/vms/vm-test/virtiofsd.sock", chCfg.Fs[0].Socket)
 	}
-	if chCfg.Payload.Cmdline != "console=hvc0 root=/dev/root rootfstype=virtiofs rw" {
-		t.Fatalf("payload.cmdline = %q, want console=hvc0 root=/dev/root rootfstype=virtiofs rw", chCfg.Payload.Cmdline)
+	if chCfg.Payload.Cmdline != "console=ttyS0 console=hvc0 root=/dev/root rootfstype=virtiofs rw" {
+		t.Fatalf("payload.cmdline = %q, want console=ttyS0 console=hvc0 root=/dev/root rootfstype=virtiofs rw", chCfg.Payload.Cmdline)
 	}
 	if !chCfg.Memory.Shared {
 		t.Fatal("memory.shared should be true when virtiofs is configured")

--- a/vm/engine/oci_runtime_prepare.go
+++ b/vm/engine/oci_runtime_prepare.go
@@ -162,6 +162,9 @@ func materializeOCIRuntimeCache(ctx context.Context, cfg *config.CocoonConfig, r
 	if err = installOCIRuntimeKernelArtifacts(workKernel, info.Config); err != nil {
 		return err
 	}
+	if err = validateOCIRuntimeInitramfsVirtiofs(filepath.Join(workKernel, "initrd.img")); err != nil {
+		return fmt.Errorf("OCI runtime initramfs check failed for %s: %w", runtimeKey, err)
+	}
 
 	if err := promoteOCIRuntimeCacheDir(workDir, cfg.OCIRuntimeEntryDir(runtimeKey)); err != nil {
 		return fmt.Errorf("promote OCI runtime cache %s: %w", runtimeKey, err)
@@ -300,27 +303,44 @@ func normalizeVirtiofsKernelCmdline(raw, virtiofsTag string) string {
 	}
 
 	fields := strings.Fields(strings.TrimSpace(raw))
-	out := make([]string, 0, len(fields)+4)
-	hasConsole := false
+	out := make([]string, 0, len(fields)+5)
 	for _, field := range fields {
 		switch {
 		case strings.HasPrefix(field, "root="),
 			strings.HasPrefix(field, "rootfstype="),
 			field == "ro",
-			field == "rw":
+			field == "rw",
+			strings.HasPrefix(field, "console="):
 			continue
-		case strings.HasPrefix(field, "console="):
-			hasConsole = true
 		}
 		out = append(out, field)
 	}
-	if !hasConsole {
-		out = append(out, "console=hvc0")
-	}
+	// Ensure serial output is always visible to boot detection (ttyS0), while
+	// keeping hvc0 as the primary console by appending it last.
+	out = append(out, "console=ttyS0", "console=hvc0")
 	// The runtime overlay upperdir is writable, so force rw semantics even if
 	// source cmdline requested ro to avoid guest booting with a read-only root.
 	out = append(out, "root="+virtiofsTag, "rootfstype=virtiofs", "rw")
 	return strings.Join(out, " ")
+}
+
+func validateOCIRuntimeInitramfsVirtiofs(initramfsPath string) error {
+	path := strings.TrimSpace(initramfsPath)
+	if path == "" {
+		return fmt.Errorf("initramfs path is empty")
+	}
+
+	found, err := oci.CheckInitramfsVirtiofsFromInitrdPath(path)
+	if err != nil {
+		return fmt.Errorf("virtiofs module detection failed for %s: %w", path, err)
+	}
+	if !found {
+		return fmt.Errorf(
+			"virtiofs module not found in initramfs %s; rebuild image/initramfs with virtiofs support before create/run",
+			path,
+		)
+	}
+	return nil
 }
 
 func statPathExists(path string) bool {

--- a/vm/engine/oci_runtime_prepare_test.go
+++ b/vm/engine/oci_runtime_prepare_test.go
@@ -1,9 +1,15 @@
 package engine
 
 import (
+	"archive/tar"
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/CMGS/cocoon/config"
+	"github.com/CMGS/cocoon/oci"
 )
 
 func TestPromoteOCIRuntimeCacheDir_NewEntry(t *testing.T) {
@@ -71,4 +77,120 @@ func TestPromoteOCIRuntimeCacheDir_RotatesExistingEntry(t *testing.T) {
 	if _, err := os.Stat(finalDir + ".old"); !os.IsNotExist(err) {
 		t.Fatalf("expected no .old dir, err=%v", err)
 	}
+}
+
+func TestNormalizeVirtiofsKernelCmdline_EnforcesSerialAndVirtioConsoles(t *testing.T) {
+	t.Parallel()
+
+	got := normalizeVirtiofsKernelCmdline("quiet splash", "/dev/root")
+	want := "quiet splash console=ttyS0 console=hvc0 root=/dev/root rootfstype=virtiofs rw"
+	if got != want {
+		t.Fatalf("normalizeVirtiofsKernelCmdline() = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeVirtiofsKernelCmdline_RewritesRootAndConsoleArgs(t *testing.T) {
+	t.Parallel()
+
+	got := normalizeVirtiofsKernelCmdline("foo=bar console=ttyS1 root=/dev/vda1 ro console=hvc0", "/dev/root")
+	want := "foo=bar console=ttyS0 console=hvc0 root=/dev/root rootfstype=virtiofs rw"
+	if got != want {
+		t.Fatalf("normalizeVirtiofsKernelCmdline() = %q, want %q", got, want)
+	}
+}
+
+func TestMaterializeOCIRuntimeCache_BadInitramfsNotPromoted(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.DefaultConfig()
+	cfg.RebaseRootDir(t.TempDir())
+	cfg.RuntimeDir = t.TempDir()
+	cfg.LogDir = t.TempDir()
+	if err := cfg.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+
+	layoutPath := t.TempDir()
+	blobDir := filepath.Join(layoutPath, "blobs", "sha256")
+	if err := os.MkdirAll(blobDir, 0o755); err != nil { //nolint:gosec // test fixture
+		t.Fatalf("mkdir blob dir: %v", err)
+	}
+
+	const (
+		runtimeKey  = "badinitrdruntimekey"
+		kernelHex   = "1111111111111111111111111111111111111111111111111111111111111111"
+		rootfsHex   = "2222222222222222222222222222222222222222222222222222222222222222"
+		manifestHex = "3333333333333333333333333333333333333333333333333333333333333333"
+	)
+
+	rootfsTar := buildLayerTarForTest(t, map[string][]byte{
+		"etc/os-release": []byte("NAME=cocoon\n"),
+	})
+	if err := os.WriteFile(filepath.Join(blobDir, rootfsHex), rootfsTar, 0o644); err != nil {
+		t.Fatalf("write rootfs blob: %v", err)
+	}
+
+	badInitrd := []byte{0xde, 0xad, 0xbe, 0xef, 0x00, 0x01}
+	kernelTar := buildLayerTarForTest(t, map[string][]byte{
+		"vmlinuz":    bytes.Repeat([]byte("K"), 2048),
+		"initrd.img": badInitrd,
+	})
+	if err := os.WriteFile(filepath.Join(blobDir, kernelHex), kernelTar, 0o644); err != nil {
+		t.Fatalf("write kernel blob: %v", err)
+	}
+
+	info := &oci.LayoutInfo{
+		ManifestDigest: "sha256:" + manifestHex,
+		Layers: []oci.LayerInfo{
+			{MediaType: oci.MediaTypeKernelLayer, Digest: "sha256:" + kernelHex},
+			{MediaType: oci.MediaTypeRootfsLayer, Digest: "sha256:" + rootfsHex},
+		},
+		Config: &oci.VMImageConfig{
+			KernelPath: "/vmlinuz",
+			InitrdPath: "/initrd.img",
+		},
+	}
+
+	err := materializeOCIRuntimeCache(t.Context(), cfg, runtimeKey, layoutPath, info)
+	if err == nil {
+		t.Fatal("expected materializeOCIRuntimeCache error, got nil")
+	}
+	if !strings.Contains(err.Error(), "OCI runtime initramfs check failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, statErr := os.Stat(cfg.OCIRuntimeEntryDir(runtimeKey)); !os.IsNotExist(statErr) {
+		t.Fatalf("runtime cache entry should not be promoted, stat err=%v", statErr)
+	}
+
+	workDirs, globErr := filepath.Glob(filepath.Join(cfg.OCIRuntimeCacheDir(), runtimeKey+"-work-*"))
+	if globErr != nil {
+		t.Fatalf("glob work dirs: %v", globErr)
+	}
+	if len(workDirs) != 0 {
+		t.Fatalf("expected no leftover work dirs, got %v", workDirs)
+	}
+}
+
+func buildLayerTarForTest(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for path, data := range files {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: path,
+			Mode: 0o644,
+			Size: int64(len(data)),
+		}); err != nil {
+			t.Fatalf("write tar header for %s: %v", path, err)
+		}
+		if _, err := tw.Write(data); err != nil {
+			t.Fatalf("write tar payload for %s: %v", path, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar writer: %v", err)
+	}
+	return buf.Bytes()
 }


### PR DESCRIPTION
## Summary

Closes #44.

This PR fixes two OCI runtime correctness issues:

1. Move the initramfs virtiofs gate to runtime materialization **before** cache promote.
2. Normalize OCI direct-boot cmdline to include both serial and virtio consoles so boot detection can observe output from serial log.

## What changed

- `vm/engine/oci_runtime_prepare.go`
  - Run `validateOCIRuntimeInitramfsVirtiofs` immediately after kernel/initrd extraction and before `promoteOCIRuntimeCacheDir`.
  - Keep invalid runtime entries from being published.
  - Update `normalizeVirtiofsKernelCmdline` to enforce:
    - `console=ttyS0`
    - `console=hvc0` (appended last; primary console)
    - `root=/dev/root rootfstype=virtiofs rw`
  - Move shared helper `validateOCIRuntimeInitramfsVirtiofs` into this file.

- `vm/engine/manager.go`
  - Remove redundant post-promote initramfs gate in `createOCIVM`.

- Tests
  - `vm/engine/oci_runtime_prepare_test.go`
    - add cmdline normalization tests
    - add regression test that bad initramfs fails materialization and does not leave promoted runtime entry
  - `vm/engine/manager_test.go`
    - update expected normalized OCI cmdline

- Docs
  - `docs/04.1-oci-vm-images.md`
    - document normalized console behavior (`ttyS0` + `hvc0`)
    - document pre-promote initramfs validation behavior

- Included repository guidance file requested in this thread:
  - `CLAUDE.md`

## Validation

- `make lint` (linux + darwin): pass
- `make test` (includes go vet linux + darwin): pass

## Risk

- Low/medium: direct-boot cmdline normalization now strips any caller-provided `console=` entries and enforces cocoon defaults for OCI virtiofs runtime.
- This is intentional to keep boot-detection path deterministic and avoid serial-log blind boot timeouts.
